### PR TITLE
Make transformations values correctly update when setting world matrix

### DIFF
--- a/Source/ChilliSource/Core/Entity/Transform.cpp
+++ b/Source/ChilliSource/Core/Entity/Transform.cpp
@@ -477,14 +477,22 @@ namespace ChilliSource
         //----------------------------------------------------------------
         void Transform::SetWorldTransform(const Matrix4& inmatTransform)
         {
-            inmatTransform.Decompose(mvWorldPosition, mvWorldScale, mqWorldOrientation);
-            
-            mmatWorldTransform = inmatTransform;
-            
+            //Change the local transform to match the given world matrix
+            if (mpParentTransform)
+            {
+                mmatTransform = inmatTransform * CSCore::Matrix4::Inverse(mpParentTransform->GetWorldTransform());
+            }
+            else
+            {
+                mmatTransform = inmatTransform;
+            }
+
+            mmatTransform.Decompose(mvPosition, mvScale, mqOrientation);
+
             OnTransformChanged();
-            
+
             mbIsTransformCacheValid = true;
-            mbIsParentTransformCacheValid = true;
+            mbIsParentTransformCacheValid = false;
         }
         //----------------------------------------------------------------
         /// Set Local Transform


### PR DESCRIPTION
Fix for #9.
Transforms don't have its own world matrix so it update based on the parent and the local transformations.
Setting the local transformations to mimic the world matrix will fix this issue.