### PR TITLE
Feature: Render to texture

### DIFF
--- a/Projects/Windows/ChilliSource.vcxproj
+++ b/Projects/Windows/ChilliSource.vcxproj
@@ -612,6 +612,7 @@
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\SizePolicy.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\SurfaceFormat.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\TargetRenderPassGroup.h" />
+    <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\TargetType.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\VerticalTextJustification.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Camera.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Camera\CameraComponent.h" />

--- a/Projects/Windows/ChilliSource.vcxproj.filters
+++ b/Projects/Windows/ChilliSource.vcxproj.filters
@@ -2828,5 +2828,8 @@
     <ClInclude Include="..\..\Source\ChilliSource\Core\Base\RenderInfo.h">
       <Filter>ChilliSource\Core\Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\TargetType.h">
+      <Filter>ChilliSource\Rendering\Base</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Projects/iOS/ChilliSource.xcodeproj/project.pbxproj
+++ b/Projects/iOS/ChilliSource.xcodeproj/project.pbxproj
@@ -1356,6 +1356,7 @@
 		81C7FFBF1C89DDE300D306F9 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		81C7FFC01C89DDE300D306F9 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		81C7FFC11C89DDE300D306F9 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		81E377C71D4F43E500128CCA /* TargetType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TargetType.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2548,6 +2549,7 @@
 				81845FAD1D3503E8004B0C46 /* SurfaceFormat.h */,
 				81845FAE1D3503E8004B0C46 /* TargetRenderPassGroup.cpp */,
 				81845FAF1D3503E8004B0C46 /* TargetRenderPassGroup.h */,
+				81E377C71D4F43E500128CCA /* TargetType.h */,
 				81845FB01D3503E8004B0C46 /* VerticalTextJustification.cpp */,
 				81845FB11D3503E8004B0C46 /* VerticalTextJustification.h */,
 			);

--- a/Source/CSBackend/Rendering/OpenGL/Base/GLContextRestorer.cpp
+++ b/Source/CSBackend/Rendering/OpenGL/Base/GLContextRestorer.cpp
@@ -175,7 +175,7 @@ namespace CSBackend
         }
         
         //------------------------------------------------------------------------------
-        void GLContextRestorer::OnRenderSnapshot(ChilliSource::RenderSnapshot& renderSnapshot) noexcept
+        void GLContextRestorer::OnRenderSnapshot(ChilliSource::RenderSnapshot& renderSnapshot, ChilliSource::IAllocator* frameAllocator) noexcept
         {
 #ifdef CS_TARGETPLATFORM_ANDROID
             auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();

--- a/Source/CSBackend/Rendering/OpenGL/Base/GLContextRestorer.cpp
+++ b/Source/CSBackend/Rendering/OpenGL/Base/GLContextRestorer.cpp
@@ -31,6 +31,7 @@
 #include <ChilliSource/Core/Base/Application.h>
 #include <ChilliSource/Core/Resource/ResourcePool.h>
 #include <ChilliSource/Rendering/Base/RenderSnapshot.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 #include <ChilliSource/Rendering/Material/Material.h>
 #include <ChilliSource/Rendering/Model/Model.h>
 #include <ChilliSource/Rendering/Model/RenderMesh.h>
@@ -175,29 +176,32 @@ namespace CSBackend
         }
         
         //------------------------------------------------------------------------------
-        void GLContextRestorer::OnRenderSnapshot(ChilliSource::RenderSnapshot& renderSnapshot, ChilliSource::IAllocator* frameAllocator) noexcept
+        void GLContextRestorer::OnRenderSnapshot(ChilliSource::TargetType targetType, ChilliSource::RenderSnapshot& renderSnapshot, ChilliSource::IAllocator* frameAllocator) noexcept
         {
 #ifdef CS_TARGETPLATFORM_ANDROID
-            auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
-            
-            for(auto& restoreMeshCommand : m_pendingRestoreMeshCommands)
+            if(targetType == ChilliSource::TargetType::k_main)
             {
-                preRenderCommandList->AddRestoreMeshCommand(restoreMeshCommand.GetRenderMesh());
+                auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
+                
+                for(auto& restoreMeshCommand : m_pendingRestoreMeshCommands)
+                {
+                    preRenderCommandList->AddRestoreMeshCommand(restoreMeshCommand.GetRenderMesh());
+                }
+                
+                for(auto& restoreTextureCommand : m_pendingRestoreTextureCommands)
+                {
+                    preRenderCommandList->AddRestoreTextureCommand(restoreTextureCommand.GetRenderTexture());
+                }
+                
+                for(auto& restoreRenderTargetGroupCommand : m_pendingRestoreRenderTargetGroupCommands)
+                {
+                    preRenderCommandList->AddRestoreRenderTargetGroupCommand(restoreRenderTargetGroupCommand.GetTargetRenderGroup());
+                }
+                
+                m_pendingRestoreMeshCommands.clear();
+                m_pendingRestoreTextureCommands.clear();
+                m_pendingRestoreRenderTargetGroupCommands.clear();
             }
-            
-            for(auto& restoreTextureCommand : m_pendingRestoreTextureCommands)
-            {
-                preRenderCommandList->AddRestoreTextureCommand(restoreTextureCommand.GetRenderTexture());
-            }
-            
-            for(auto& restoreRenderTargetGroupCommand : m_pendingRestoreRenderTargetGroupCommands)
-            {
-                preRenderCommandList->AddRestoreRenderTargetGroupCommand(restoreRenderTargetGroupCommand.GetTargetRenderGroup());
-            }
-            
-            m_pendingRestoreMeshCommands.clear();
-            m_pendingRestoreTextureCommands.clear();
-            m_pendingRestoreRenderTargetGroupCommands.clear();
 #endif
         }
         

--- a/Source/CSBackend/Rendering/OpenGL/Base/GLContextRestorer.h
+++ b/Source/CSBackend/Rendering/OpenGL/Base/GLContextRestorer.h
@@ -105,8 +105,10 @@ namespace CSBackend
             ///
             /// @param renderSnapshot
             ///     The render snapshot object which contains all snapshotted data.
+            /// @param frameAllocator
+            ///     Allocate memory for this render frame from here
             ///
-            void OnRenderSnapshot(ChilliSource::RenderSnapshot& renderSnapshot) noexcept override;
+            void OnRenderSnapshot(ChilliSource::RenderSnapshot& renderSnapshot, ChilliSource::IAllocator* frameAllocator) noexcept override;
             
             /// Called when the application delegate is suspended. This is called directly
             /// from lifecycle manager and will be called before the OnSuspend.

--- a/Source/CSBackend/Rendering/OpenGL/Base/GLContextRestorer.h
+++ b/Source/CSBackend/Rendering/OpenGL/Base/GLContextRestorer.h
@@ -103,12 +103,14 @@ namespace CSBackend
             /// The render snapshot event can be implemented by a system to
             /// allow it to snapshot any data which pertains to the renderer.
             ///
+            /// @param targetType
+            ///     Whether the snapshot is for the main screen or an offscreen render target
             /// @param renderSnapshot
             ///     The render snapshot object which contains all snapshotted data.
             /// @param frameAllocator
             ///     Allocate memory for this render frame from here
             ///
-            void OnRenderSnapshot(ChilliSource::RenderSnapshot& renderSnapshot, ChilliSource::IAllocator* frameAllocator) noexcept override;
+            void OnRenderSnapshot(ChilliSource::TargetType targetType, ChilliSource::RenderSnapshot& renderSnapshot, ChilliSource::IAllocator* frameAllocator) noexcept override;
             
             /// Called when the application delegate is suspended. This is called directly
             /// from lifecycle manager and will be called before the OnSuspend.

--- a/Source/CSBackend/Rendering/OpenGL/Base/RenderCommandProcessor.cpp
+++ b/Source/CSBackend/Rendering/OpenGL/Base/RenderCommandProcessor.cpp
@@ -600,7 +600,19 @@ namespace CSBackend
         {
             if (m_currentRenderTargetGroup)
             {
-                //TODO: Update texture data for bound target group, when render to texture is implemented.
+                // For some platforms we need to store a shadow copy of textures in memory
+                // so we can restore if the context is lost. This updates that shadow copy
+                if(m_currentRenderTargetGroup->GetColourTarget())
+                {
+                    auto glColourTexture = static_cast<GLTexture*>(m_currentRenderTargetGroup->GetColourTarget()->GetExtraData());
+                    glColourTexture->UpdateRestorableBackup();
+                }
+                
+                if(m_currentRenderTargetGroup->GetDepthTarget())
+                {
+                    auto glDepthTexture = static_cast<GLTexture*>(m_currentRenderTargetGroup->GetDepthTarget()->GetExtraData());
+                    glDepthTexture->UpdateRestorableBackup();
+                }
             }
             
             ResetCache();

--- a/Source/CSBackend/Rendering/OpenGL/Texture/GLTexture.h
+++ b/Source/CSBackend/Rendering/OpenGL/Texture/GLTexture.h
@@ -67,6 +67,12 @@ namespace CSBackend
             ///
             bool IsDataInvalid() const noexcept { return m_invalidData; }
             
+            /// Called prior to the app suspending and losing context to update
+            /// the restorable copy of the image data. This is used primarily
+            /// or render textures which are changed after creation
+            ///
+            void UpdateRestorableBackup() noexcept;
+            
             /// Called when we should restore any cached texture data.
             ///
             /// This will assert if called without having data backed up.

--- a/Source/ChilliSource/Core/Base/Application.cpp
+++ b/Source/ChilliSource/Core/Base/Application.cpp
@@ -390,6 +390,7 @@ namespace ChilliSource
         CS_ASSERT(activeState, "Must have active state.");
  
         auto scenes = activeState->GetScenes();
+        CS_ASSERT(scenes.size() > 0, "No scenes on active state");
         
         m_currentRenderSnapshots.reserve(scenes.size());
 

--- a/Source/ChilliSource/Core/Base/Application.cpp
+++ b/Source/ChilliSource/Core/Base/Application.cpp
@@ -359,8 +359,6 @@ namespace ChilliSource
         //Load the app config set preferred FPS.
         m_appConfig->Load();
     }
-    
-    std::vector<RenderSnapshot> snapshots;
 
     //------------------------------------------------------------------------------
     void Application::ProcessRenderSnapshotEvent() noexcept
@@ -376,7 +374,7 @@ namespace ChilliSource
     //------------------------------------------------------------------------------
     void Application::RenderToTarget(Scene* scene, TargetGroup* target)
     {
-        CS_ASSERT(ChilliSource::Application::Get()->GetTaskScheduler()->IsMainThread(), "Tried to render to texture from background thread.");
+        CS_ASSERT(ChilliSource::Application::Get()->GetTaskScheduler()->IsMainThread(), "Tried to render to target from background thread.");
         
         auto clearColour = scene->GetClearColour();
         auto camera = scene->GetActiveCamera();
@@ -404,15 +402,15 @@ namespace ChilliSource
             
             m_stateManager->RenderSnapshotStates(renderSnapshot, frameAllocator);
             
-            m_renderer->ProcessRenderSnapshots(std::move(frameAllocator), std::move(renderSnapshot), std::move(snapshots));
-            snapshots.clear();
+            m_renderer->ProcessRenderSnapshots(std::move(frameAllocator), std::move(renderSnapshot), std::move(m_currentRenderSnapshots));
+            m_currentRenderSnapshots.clear();
         }
         else
         {
             IAllocator* frameAllocator = m_renderer->GetFrameAllocatorQueue().Front();
             RenderSnapshot renderSnapshot = m_renderer->CreateRenderSnapshot(target->GetRenderTargetGroup(), target->GetRenderTargetGroup()->GetResolution(), clearColour, renderCamera);
             scene->RenderSnapshotEntities(renderSnapshot, frameAllocator);
-            snapshots.push_back(std::move(renderSnapshot));
+            m_currentRenderSnapshots.push_back(std::move(renderSnapshot));
         }
     }
     

--- a/Source/ChilliSource/Core/Base/Application.h
+++ b/Source/ChilliSource/Core/Base/Application.h
@@ -312,16 +312,17 @@ namespace ChilliSource
         ///
         const WidgetFactory* GetWidgetFactory() const noexcept;
         
-        /// Takes a snapshot of the given scene and renders it to the given offscree
-        /// render target during the render stage of the application. NOTE: This
-        /// means the texture of the target will not be populated til next frame.
+        /// Takes a snapshot of the given scene and renders it to its
+        /// render target during the render stage of the application.
+        /// This is used mostly for single shot render to texture
+        /// NOTE: This means the texture of the target will not be populated til next frame.
         ///
         /// @param scene
-        ///     Scene that should be rendered to given target
+        ///     Scene that should be rendered
         /// @param target
-        ///     Target to render into
+        ///     Optiona, if wanting to render the scene to a target other than its own
         ///
-        void RenderToTarget(Scene* scene, TargetGroup* target);
+        void RenderScene(Scene* scene, TargetGroup* target = nullptr) noexcept;
 
         virtual ~Application() noexcept;
         
@@ -369,7 +370,8 @@ namespace ChilliSource
         
         /// Sends the render snapshot event to all active systems and components
         /// that are current in the scene to generate the render snapshot. This
-        /// snapshot is then passed to the render pipeline for processing.
+        /// snapshot is then passed to the render pipeline for processing. This is done
+        /// for all enabled scenes
         ///
         void ProcessRenderSnapshotEvent() noexcept;
         
@@ -441,9 +443,8 @@ namespace ChilliSource
         ///
         void Destroy() noexcept;
         
-        std::vector<AppSystemUPtr> m_systems;
-        
         std::vector<RenderSnapshot> m_currentRenderSnapshots;
+        std::vector<AppSystemUPtr> m_systems;
         
         ResourcePool* m_resourcePool = nullptr;
         StateManager* m_stateManager = nullptr;

--- a/Source/ChilliSource/Core/Base/Application.h
+++ b/Source/ChilliSource/Core/Base/Application.h
@@ -320,7 +320,7 @@ namespace ChilliSource
         /// @param scene
         ///     Scene that should be rendered
         /// @param target
-        ///     Optiona, if wanting to render the scene to a target other than its own
+        ///     Optional, if wanting to render the scene to a target other than its own
         ///
         void RenderScene(Scene* scene, TargetGroup* target = nullptr) noexcept;
 

--- a/Source/ChilliSource/Core/Base/Application.h
+++ b/Source/ChilliSource/Core/Base/Application.h
@@ -312,6 +312,15 @@ namespace ChilliSource
         ///
         const WidgetFactory* GetWidgetFactory() const noexcept;
         
+        /// Takes a snapshot of the given scene and renders it to the given offscree
+        /// render target during the render stage of the application. NOTE: This
+        /// means the texture of the target will not be populated til next frame.
+        ///
+        /// @param scene
+        ///     Scene that should be rendered to given target
+        /// @param target
+        ///     Target to render into
+        ///
         void RenderToTarget(Scene* scene, TargetGroup* target);
 
         virtual ~Application() noexcept;
@@ -449,7 +458,6 @@ namespace ChilliSource
         SystemInfoCUPtr m_systemInfo;
         
         std::atomic<u32> m_frameIndex;
-        std::atomic<u32> m_renderFrameIndex;
         TimeIntervalSecs m_currentAppTime = 0;
         f32 m_updateInterval;
         f32 m_updateSpeed = 1.0f;

--- a/Source/ChilliSource/Core/Base/Application.h
+++ b/Source/ChilliSource/Core/Base/Application.h
@@ -443,6 +443,8 @@ namespace ChilliSource
         
         std::vector<AppSystemUPtr> m_systems;
         
+        std::vector<RenderSnapshot> m_currentRenderSnapshots;
+        
         ResourcePool* m_resourcePool = nullptr;
         StateManager* m_stateManager = nullptr;
         TaskScheduler* m_taskScheduler = nullptr;

--- a/Source/ChilliSource/Core/Base/Application.h
+++ b/Source/ChilliSource/Core/Base/Application.h
@@ -311,18 +311,6 @@ namespace ChilliSource
         /// @return A const pointer to the widget factory system.
         ///
         const WidgetFactory* GetWidgetFactory() const noexcept;
-        
-        /// Takes a snapshot of the given scene and renders it to its
-        /// render target during the render stage of the application.
-        /// This is used mostly for single shot render to texture
-        /// NOTE: This means the texture of the target will not be populated til next frame.
-        ///
-        /// @param scene
-        ///     Scene that should be rendered
-        /// @param target
-        ///     Optional, if wanting to render the scene to a target other than its own
-        ///
-        void RenderScene(Scene* scene, TargetGroup* target = nullptr) noexcept;
 
         virtual ~Application() noexcept;
         
@@ -443,7 +431,21 @@ namespace ChilliSource
         ///
         void Destroy() noexcept;
         
-        std::vector<RenderSnapshot> m_currentRenderSnapshots;
+        friend class Scene;
+        
+        /// Takes a snapshot of the given scene and renders it to its
+        /// render target during the render stage of the application.
+        /// This is used mostly for single shot render to texture
+        /// NOTE: This means the texture of the target will not be populated til next frame.
+        ///
+        /// @param scene
+        ///     Scene that should be rendered
+        /// @param target
+        ///     Optional, if wanting to render the scene to a target other than its own
+        ///
+        void RenderScene(Scene* scene, TargetGroup* target = nullptr) noexcept;
+        
+        std::vector<RenderSnapshot> m_pendingRenderSnapshots;
         std::vector<AppSystemUPtr> m_systems;
         
         ResourcePool* m_resourcePool = nullptr;

--- a/Source/ChilliSource/Core/Base/Application.h
+++ b/Source/ChilliSource/Core/Base/Application.h
@@ -311,6 +311,8 @@ namespace ChilliSource
         /// @return A const pointer to the widget factory system.
         ///
         const WidgetFactory* GetWidgetFactory() const noexcept;
+        
+        void RenderToTarget(Scene* scene, TargetGroup* target);
 
         virtual ~Application() noexcept;
         
@@ -447,6 +449,7 @@ namespace ChilliSource
         SystemInfoCUPtr m_systemInfo;
         
         std::atomic<u32> m_frameIndex;
+        std::atomic<u32> m_renderFrameIndex;
         TimeIntervalSecs m_currentAppTime = 0;
         f32 m_updateInterval;
         f32 m_updateSpeed = 1.0f;

--- a/Source/ChilliSource/Core/Entity/Component.h
+++ b/Source/ChilliSource/Core/Entity/Component.h
@@ -135,8 +135,10 @@ namespace ChilliSource
         ///
         /// @param in_renderSnapshot - The render snapshot
         /// object which contains all snapshotted data.
+        /// @param frameAllocator - Use this to allocate any memory
+        /// for this render frame
         //----------------------------------------------------
-        virtual void OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept {};
+        virtual void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept {};
         //----------------------------------------------------
         /// Called when the application is backgrounded while
         /// the owning entity is in the scene. This will also

--- a/Source/ChilliSource/Core/Entity/Entity.cpp
+++ b/Source/ChilliSource/Core/Entity/Entity.cpp
@@ -441,11 +441,11 @@ namespace ChilliSource
     }
     //-------------------------------------------------------------
     //-------------------------------------------------------------
-    void Entity::OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept
+    void Entity::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         for(u32 i=0; i<m_components.size(); ++i)
         {
-            m_components[i]->OnRenderSnapshot(in_renderSnapshot);
+            m_components[i]->OnRenderSnapshot(renderSnapshot, frameAllocator);
         }
     }
     //-------------------------------------------------------------

--- a/Source/ChilliSource/Core/Entity/Entity.h
+++ b/Source/ChilliSource/Core/Entity/Entity.h
@@ -442,10 +442,12 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The render snapshot object which
+        /// @param renderSnapshot - The render snapshot object which
         /// contains all snapshotted data.
+        /// @param frameAllocator - Allocate any memory needed for rendering
+        /// a frame from here
         //-------------------------------------------------------------
-        void OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
         //-------------------------------------------------------------
         /// Called when the application is backgrounded while the entity
         /// is in the scene. This will also be called when the entity is

--- a/Source/ChilliSource/Core/Image/ImageFormatConverter.cpp
+++ b/Source/ChilliSource/Core/Image/ImageFormatConverter.cpp
@@ -36,15 +36,6 @@ namespace ChilliSource
 {
     namespace ImageFormatConverter
     {
-#ifdef CS_TARGETPLATFORM_WINDOWS
-        //------------------------------------------------
-        //------------------------------------------------
-        ImageBuffer::ImageBuffer(ImageBuffer&& in_other)
-        {
-            m_data = std::move(in_other.m_data);
-            m_size = in_other.m_size;
-        }
-#endif
         //---------------------------------------------------
         //---------------------------------------------------
         void RGBA8888ToRGB888(Image* in_image)

--- a/Source/ChilliSource/Core/Image/ImageFormatConverter.h
+++ b/Source/ChilliSource/Core/Image/ImageFormatConverter.h
@@ -52,27 +52,6 @@ namespace ChilliSource
         {
             Image::ImageDataUPtr m_data;
             u32 m_size = 0;
-
-#ifdef CS_TARGETPLATFORM_WINDOWS
-            //------------------------------------------------
-            /// Visual C++ 12 doesn't support implicit move
-            /// constructors, so this has to be manually
-            /// specified.
-            ///
-            /// @author Ian Copland
-            //------------------------------------------------
-            ImageBuffer() = default;
-            //------------------------------------------------
-            /// Visual C++ 12 doesn't support implicit move
-            /// constructors, so this has to be manually
-            /// specified.
-            ///
-            /// @author Ian Copland
-            ///
-            /// @param The image buffer to move.
-            //------------------------------------------------
-            ImageBuffer(ImageBuffer&& in_other);
-#endif
         };
         //---------------------------------------------------
         /// Converts an Image in format RGBA8888 to RGB888

--- a/Source/ChilliSource/Core/Scene/Scene.cpp
+++ b/Source/ChilliSource/Core/Scene/Scene.cpp
@@ -95,11 +95,11 @@ namespace ChilliSource
     }
     //-------------------------------------------------------
     //-------------------------------------------------------
-    void Scene::RenderSnapshotEntities(RenderSnapshot& in_renderSnapshot) noexcept
+    void Scene::RenderSnapshotEntities(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         for(u32 i=0; i<m_entities.size(); ++i)
         {
-            m_entities[i]->OnRenderSnapshot(in_renderSnapshot);
+            m_entities[i]->OnRenderSnapshot(renderSnapshot, frameAllocator);
         }
     }
     //-------------------------------------------------------

--- a/Source/ChilliSource/Core/Scene/Scene.cpp
+++ b/Source/ChilliSource/Core/Scene/Scene.cpp
@@ -27,6 +27,7 @@
 //
 
 #include <ChilliSource/Core/Scene/Scene.h>
+#include <ChilliSource/Core/Base/Application.h>
 #include <ChilliSource/Rendering/Target/TargetGroup.h>
 
 #include <algorithm>
@@ -37,13 +38,13 @@ namespace ChilliSource
     
     //-------------------------------------------------------
     //-------------------------------------------------------
-    SceneUPtr Scene::Create(TargetGroupUPtr renderTarget)
+    SceneUPtr Scene::Create(TargetGroupUPtr renderTarget) noexcept
     {
         return SceneUPtr(new Scene(std::move(renderTarget)));
     }
     //-------------------------------------------------------
     //-------------------------------------------------------
-    Scene::Scene(TargetGroupUPtr renderTarget)
+    Scene::Scene(TargetGroupUPtr renderTarget) noexcept
     : m_renderTarget(std::move(renderTarget))
     {
     }
@@ -184,6 +185,15 @@ namespace ChilliSource
         
         m_entities.clear();
     }
+    
+    //------------------------------------------------------------------------------
+    void Scene::Render(TargetGroup* target) noexcept
+    {
+        CS_ASSERT(target != nullptr || m_renderTarget != nullptr, "Cannot force render the main scene");
+        
+        Application::Get()->RenderScene(this, target);
+    }
+    
     //-------------------------------------------------------
     //-------------------------------------------------------
     const SharedEntityList& Scene::GetEntities() const

--- a/Source/ChilliSource/Core/Scene/Scene.cpp
+++ b/Source/ChilliSource/Core/Scene/Scene.cpp
@@ -27,6 +27,7 @@
 //
 
 #include <ChilliSource/Core/Scene/Scene.h>
+#include <ChilliSource/Rendering/Target/TargetGroup.h>
 
 #include <algorithm>
 
@@ -36,13 +37,14 @@ namespace ChilliSource
     
     //-------------------------------------------------------
     //-------------------------------------------------------
-    SceneUPtr Scene::Create()
+    SceneUPtr Scene::Create(TargetGroupUPtr renderTarget)
     {
-        return SceneUPtr(new Scene());
+        return SceneUPtr(new Scene(std::move(renderTarget)));
     }
     //-------------------------------------------------------
     //-------------------------------------------------------
-    Scene::Scene()
+    Scene::Scene(TargetGroupUPtr renderTarget)
+    : m_renderTarget(std::move(renderTarget))
     {
     }
     //-------------------------------------------------------
@@ -79,18 +81,24 @@ namespace ChilliSource
     //-------------------------------------------------------
     void Scene::UpdateEntities(f32 in_timeSinceLastUpdate)
     {
-        for(u32 i = 0; i < m_entities.size(); ++i)
+        if(m_enabled)
         {
-            m_entities[i]->OnUpdate(in_timeSinceLastUpdate);
+            for(u32 i = 0; i < m_entities.size(); ++i)
+            {
+                m_entities[i]->OnUpdate(in_timeSinceLastUpdate);
+            }
         }
     }
     //-------------------------------------------------------
     //-------------------------------------------------------
     void Scene::FixedUpdateEntities(f32 in_fixedTimeSinceLastUpdate)
     {
-        for(u32 i=0; i<m_entities.size(); ++i)
+        if(m_enabled)
         {
-            m_entities[i]->OnFixedUpdate(in_fixedTimeSinceLastUpdate);
+            for(u32 i=0; i<m_entities.size(); ++i)
+            {
+                m_entities[i]->OnFixedUpdate(in_fixedTimeSinceLastUpdate);
+            }
         }
     }
     //-------------------------------------------------------
@@ -260,6 +268,12 @@ namespace ChilliSource
             it->swap(m_entities.back());
             m_entities.pop_back();
         }
+    }
+    //--------------------------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------------------------------
+    void Scene::OnDestroy() noexcept
+    {
+        m_renderTarget.reset();
     }
     //--------------------------------------------------------------------------------------------------
     //--------------------------------------------------------------------------------------------------

--- a/Source/ChilliSource/Core/Scene/Scene.h
+++ b/Source/ChilliSource/Core/Scene/Scene.h
@@ -166,10 +166,12 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The render snapshot object
+        /// @param renderSnapshot - The render snapshot object
         /// which contains all snapshotted data.
+        /// @param frameAllocator - Allocate any render frame data
+        /// from here
         //-------------------------------------------------------
-        void RenderSnapshotEntities(RenderSnapshot& in_renderSnapshot) noexcept;
+        void RenderSnapshotEntities(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
         //-------------------------------------------------------
         /// Sends the background event on to the entities.
         ///

--- a/Source/ChilliSource/Core/Scene/Scene.h
+++ b/Source/ChilliSource/Core/Scene/Scene.h
@@ -35,6 +35,7 @@
 #include <ChilliSource/Core/Math/Geometry/Shapes.h>
 #include <ChilliSource/Core/System/StateSystem.h>
 #include <ChilliSource/Core/Volume/VolumeComponent.h>
+#include <ChilliSource/Rendering/Target/TargetGroup.h>
 
 namespace ChilliSource
 {

--- a/Source/ChilliSource/Core/Scene/Scene.h
+++ b/Source/ChilliSource/Core/Scene/Scene.h
@@ -53,10 +53,10 @@ namespace ChilliSource
         ///
         /// @author S Downie
         ///
-        /// @param Input system used by the window to listen
-        /// for input events
+        /// @param renderTarget
+        ///     The target into which the scene renders, if null renders to screen
         //-------------------------------------------------------
-        static SceneUPtr Create();
+        static SceneUPtr Create(TargetGroupUPtr renderTarget = nullptr);
         
         //-------------------------------------------------------
         /// Destructor
@@ -75,6 +75,19 @@ namespace ChilliSource
         /// @return Whether the system has the given interface
         //-------------------------------------------------------
         bool IsA(InterfaceIDType in_interfaceId) const override;
+        
+        /// Enable updating and rendering on the scene
+        ///
+        void Enable() noexcept { m_enabled = true; }
+        
+        /// Disable updating and rendering on the scene
+        ///
+        void Disable() noexcept { m_enabled = false; }
+        
+        /// @return TRUE if the scene is updating and rendering
+        ///
+        bool IsEnabled() const noexcept { return m_enabled; }
+        
         //-------------------------------------------------------
         /// Add an entity to the scene. This entity cannot
         /// exist on another scene prior to adding. The entity
@@ -132,6 +145,10 @@ namespace ChilliSource
         /// there isn't one.
         //------------------------------------------------------
         CameraComponent* GetActiveCamera() const noexcept { return m_activeCameraComponent; }
+        //------------------------------------------------------
+        /// @return The render target, if nullptr then renders to screen
+        //------------------------------------------------------
+        TargetGroup* GetRenderTarget() const noexcept { return m_renderTarget.get(); }
         //-------------------------------------------------------
         /// Sends the resume event on to the entities.
         ///
@@ -251,8 +268,11 @@ namespace ChilliSource
         /// Private to enforce use of factory method
         ///
         /// @author S Downie
+        ///
+        /// @param renderTarget
+        ///     The target into which the scene renders, if null renders to screen
         //-------------------------------------------------------
-        Scene();
+        Scene(TargetGroupUPtr renderTarget);
         //-------------------------------------------------------
         /// Remove the entity from the scene
         ///
@@ -262,13 +282,23 @@ namespace ChilliSource
         //-------------------------------------------------------
         void Remove(Entity* inpEntity);
         
+        //------------------------------------------------
+        /// Called when the owning state is being destroyed.
+        /// Used to release held objects
+        ///
+        /// @author S Downie
+        //------------------------------------------------
+        void OnDestroy() noexcept override;
+        
     private:
         
         SharedEntityList m_entities;
         Colour m_clearColour;
         bool m_entitiesActive = false;
         bool m_entitiesForegrounded = false;
+        bool m_enabled = true;
         CameraComponent* m_activeCameraComponent = nullptr;
+        TargetGroupUPtr m_renderTarget;
     };		
 }
 

--- a/Source/ChilliSource/Core/Scene/Scene.h
+++ b/Source/ChilliSource/Core/Scene/Scene.h
@@ -57,7 +57,7 @@ namespace ChilliSource
         /// @param renderTarget
         ///     The target into which the scene renders, if null renders to screen
         //-------------------------------------------------------
-        static SceneUPtr Create(TargetGroupUPtr renderTarget = nullptr);
+        static SceneUPtr Create(TargetGroupUPtr renderTarget) noexcept;
         
         //-------------------------------------------------------
         /// Destructor
@@ -77,13 +77,12 @@ namespace ChilliSource
         //-------------------------------------------------------
         bool IsA(InterfaceIDType in_interfaceId) const override;
         
-        /// Enable updating and rendering on the scene
+        /// Enable/Disable updating and rendering on the scene
         ///
-        void Enable() noexcept { m_enabled = true; }
-        
-        /// Disable updating and rendering on the scene
+        /// @param enabled
+        ///     True if enabling, False if disabling
         ///
-        void Disable() noexcept { m_enabled = false; }
+        void SetEnabled(bool enabled) noexcept { m_enabled = enabled; }
         
         /// @return TRUE if the scene is updating and rendering
         ///
@@ -202,6 +201,21 @@ namespace ChilliSource
         /// @author Ian Copland
         //-------------------------------------------------------
         void SuspendEntities();
+        
+        /// Takes a snapshot of the scene and renders it to its
+        /// render target during the render stage of the application.
+        ///
+        /// Should only be called directly by app if performing single shot RTT on a disabled scene
+        ///
+        /// NOTE: The texture of the target will not be populated until next frame.
+        ///
+        /// @param scene
+        ///     Scene that should be rendered
+        /// @param target
+        ///     Optional, if wanting to render the scene to a target other than its own
+        ///
+        void Render(TargetGroup* target = nullptr) noexcept;
+        
         //--------------------------------------------------------------------------------------------------
         /// Traverses the contents of the scene and adds any objects that intersect with the ray to the
         /// list. The list order is undefined. Use the query intersection value on the volume component
@@ -273,7 +287,7 @@ namespace ChilliSource
         /// @param renderTarget
         ///     The target into which the scene renders, if null renders to screen
         //-------------------------------------------------------
-        Scene(TargetGroupUPtr renderTarget);
+        Scene(TargetGroupUPtr renderTarget) noexcept;
         //-------------------------------------------------------
         /// Remove the entity from the scene
         ///

--- a/Source/ChilliSource/Core/State/State.cpp
+++ b/Source/ChilliSource/Core/State/State.cpp
@@ -32,6 +32,7 @@
 #include <ChilliSource/Core/State/StateManager.h>
 #include <ChilliSource/Core/Base/Application.h>
 #include <ChilliSource/Input/Gesture/GestureSystem.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 #include <ChilliSource/Rendering/Target/TargetGroup.h>
 #include <ChilliSource/UI/Base/Canvas.h>
 
@@ -44,7 +45,7 @@ namespace ChilliSource
         m_canAddSystems = true;
         
         //Create the default systems and main scene
-        m_scenes.push_back(CreateSystem<Scene>());
+        CreateSystem<Scene>(nullptr);
         m_canvas = CreateSystem<Canvas>();
         CreateSystem<GestureSystem>();
         
@@ -55,10 +56,14 @@ namespace ChilliSource
         
         for(auto& system : m_systems)
         {
-            if(system->IsA<Scene>() && system.get() != m_scenes[0])
-            {
-                m_scenes.push_back(static_cast<Scene*>(system.get()));
-            }
+           if(system->IsA<Scene>())
+           {
+               m_scenes.push_back(static_cast<Scene*>(system.get()));
+           }
+        }
+        
+        for(auto& system : m_systems)
+        {
             system->OnInit();
         }
         
@@ -130,12 +135,14 @@ namespace ChilliSource
     }
     //-----------------------------------------
     //-----------------------------------------
-    void State::RenderSnapshot(class RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
+    void State::RenderSnapshot(TargetType targetType, class RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         for(auto& system : m_systems)
         {
-            system->OnRenderSnapshot(renderSnapshot, frameAllocator);
+            system->OnRenderSnapshot(targetType, renderSnapshot, frameAllocator);
         }
+        
+        OnRenderSnapshot(targetType, renderSnapshot, frameAllocator);
     }
     //-----------------------------------------
     //-----------------------------------------
@@ -196,13 +203,13 @@ namespace ChilliSource
     }
     //------------------------------------------
     //------------------------------------------
-    Scene* State::GetScene()
+    Scene* State::GetMainScene() noexcept
     {
         return m_scenes[0];
     }
     //------------------------------------------
     //------------------------------------------
-    const Scene* State::GetScene() const
+    const Scene* State::GetMainScene() const noexcept
     {
         return m_scenes[0];
     }

--- a/Source/ChilliSource/Core/State/State.cpp
+++ b/Source/ChilliSource/Core/State/State.cpp
@@ -32,6 +32,7 @@
 #include <ChilliSource/Core/State/StateManager.h>
 #include <ChilliSource/Core/Base/Application.h>
 #include <ChilliSource/Input/Gesture/GestureSystem.h>
+#include <ChilliSource/Rendering/Target/TargetGroup.h>
 #include <ChilliSource/UI/Base/Canvas.h>
 
 namespace ChilliSource
@@ -42,8 +43,8 @@ namespace ChilliSource
     {
         m_canAddSystems = true;
         
-        //Create the default systems
-        m_scene = CreateSystem<Scene>();
+        //Create the default systems and main scene
+        m_scenes.push_back(CreateSystem<Scene>());
         m_canvas = CreateSystem<Canvas>();
         CreateSystem<GestureSystem>();
         
@@ -54,6 +55,10 @@ namespace ChilliSource
         
         for(auto& system : m_systems)
         {
+            if(system->IsA<Scene>() && system.get() != m_scenes[0])
+            {
+                m_scenes.push_back(static_cast<Scene*>(system.get()));
+            }
             system->OnInit();
         }
         
@@ -68,7 +73,10 @@ namespace ChilliSource
             system->OnResume();
         }
         
-        m_scene->ResumeEntities();
+        for(auto scene : m_scenes)
+        {
+            scene->ResumeEntities();
+        }
         
         OnResume();
     }
@@ -81,7 +89,10 @@ namespace ChilliSource
             system->OnForeground();
         }
         
-        m_scene->ForegroundEntities();
+        for(auto scene : m_scenes)
+        {
+            scene->ForegroundEntities();
+        }
         
         OnForeground();
     }
@@ -94,7 +105,10 @@ namespace ChilliSource
             system->OnUpdate(in_timeSinceLastUpdate);
         }
         
-        m_scene->UpdateEntities(in_timeSinceLastUpdate);
+        for(auto scene : m_scenes)
+        {
+            scene->UpdateEntities(in_timeSinceLastUpdate);
+        }
         
         OnUpdate(in_timeSinceLastUpdate);
     }
@@ -107,7 +121,10 @@ namespace ChilliSource
             system->OnFixedUpdate(in_fixedTimeSinceLastUpdate);
         }
         
-        m_scene->FixedUpdateEntities(in_fixedTimeSinceLastUpdate);
+        for(auto scene : m_scenes)
+        {
+            scene->FixedUpdateEntities(in_fixedTimeSinceLastUpdate);
+        }
         
         OnFixedUpdate(in_fixedTimeSinceLastUpdate);
     }
@@ -119,8 +136,6 @@ namespace ChilliSource
         {
             system->OnRenderSnapshot(renderSnapshot, frameAllocator);
         }
-        
-        m_scene->RenderSnapshotEntities(renderSnapshot, frameAllocator);
     }
     //-----------------------------------------
     //-----------------------------------------
@@ -128,7 +143,10 @@ namespace ChilliSource
     {
         OnBackground();
         
-        m_scene->BackgroundEntities();
+        for (auto it = m_scenes.rbegin(); it != m_scenes.rend(); ++it)
+        {
+            (*it)->BackgroundEntities();
+        }
         
         for (auto it = m_systems.rbegin(); it != m_systems.rend(); ++it)
         {
@@ -141,7 +159,10 @@ namespace ChilliSource
     {
         OnSuspend();
         
-        m_scene->SuspendEntities();
+        for (auto it = m_scenes.rbegin(); it != m_scenes.rend(); ++it)
+        {
+            (*it)->SuspendEntities();
+        }
         
         for(auto it = m_systems.rbegin(); it != m_systems.rend(); ++it)
         {
@@ -154,7 +175,10 @@ namespace ChilliSource
     {
         OnDestroy();
         
-        m_scene->RemoveAllEntities();
+        for (auto it = m_scenes.rbegin(); it != m_scenes.rend(); ++it)
+        {
+            (*it)->RemoveAllEntities();
+        }
         
         for(auto it = m_systems.rbegin(); it != m_systems.rend(); ++it)
         {
@@ -174,13 +198,13 @@ namespace ChilliSource
     //------------------------------------------
     Scene* State::GetScene()
     {
-        return m_scene;
+        return m_scenes[0];
     }
     //------------------------------------------
     //------------------------------------------
     const Scene* State::GetScene() const
     {
-        return m_scene;
+        return m_scenes[0];
     }
     //------------------------------------------
     //------------------------------------------

--- a/Source/ChilliSource/Core/State/State.cpp
+++ b/Source/ChilliSource/Core/State/State.cpp
@@ -113,16 +113,14 @@ namespace ChilliSource
     }
     //-----------------------------------------
     //-----------------------------------------
-    void State::RenderSnapshot(class RenderSnapshot& in_renderSnapshot) noexcept
+    void State::RenderSnapshot(class RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         for(auto& system : m_systems)
         {
-            system->OnRenderSnapshot(in_renderSnapshot);
+            system->OnRenderSnapshot(renderSnapshot, frameAllocator);
         }
         
-        m_scene->RenderSnapshotEntities(in_renderSnapshot);
-        
-        OnRenderSnapshot(in_renderSnapshot);
+        m_scene->RenderSnapshotEntities(renderSnapshot, frameAllocator);
     }
     //-----------------------------------------
     //-----------------------------------------

--- a/Source/ChilliSource/Core/State/State.h
+++ b/Source/ChilliSource/Core/State/State.h
@@ -67,15 +67,21 @@ namespace ChilliSource
         //----------------------------------------------------
         /// @author S Downie
         ///
-        /// @return A pointer to the scene.
+        /// @return A pointer to the main scene (that renders to screen).
         //----------------------------------------------------
         Scene* GetScene();
         //----------------------------------------------------
         /// @author Ian Copland
         ///
-        /// @return A const pointer to the scene.
+        /// @return A const pointer to the main scene (that renders to screen).
         //----------------------------------------------------
         const Scene* GetScene() const;
+        //----------------------------------------------------
+        /// @author S Downie
+        ///
+        /// @return List of pointers to the scenes (main and offscreen).
+        //----------------------------------------------------
+        const std::vector<Scene*>& GetScenes() const noexcept { return m_scenes; }
         //----------------------------------------------------
         /// @author S Downie
         ///
@@ -345,7 +351,7 @@ namespace ChilliSource
         
         std::vector<StateSystemUPtr> m_systems;
         
-        Scene* m_scene = nullptr;
+        std::vector<Scene*> m_scenes;
         Canvas* m_canvas = nullptr;
         bool m_canAddSystems = false;
         

--- a/Source/ChilliSource/Core/State/State.h
+++ b/Source/ChilliSource/Core/State/State.h
@@ -208,11 +208,14 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The render
+        /// @param renderSnapshot - The render
         /// snapshot object which contains all
         /// snapshotted data.
+        /// @param frameAllocator - Allocate
+        /// any data required for rendering this frame
+        /// from here
         //-----------------------------------------
-        void RenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept;
+        void RenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
         //-----------------------------------------
         /// Triggered when a state is the
         /// active state in the state manager and
@@ -307,19 +310,6 @@ namespace ChilliSource
         /// @param Fixed time since last update (Secs)
         //-----------------------------------------
         virtual void OnFixedUpdate(f32 in_deltaTime){};
-        //-----------------------------------------
-        /// The render snapshot event can be
-        /// implemented by a state to allow it to
-        /// snapshot any data which pertains to the
-        /// renderer.
-        ///
-        /// @author Ian Copland
-        ///
-        /// @param in_renderSnapshot - The render
-        /// snapshot object which contains all
-        /// snapshotted data.
-        //-----------------------------------------
-        virtual void OnRenderSnapshot(class RenderSnapshot& in_renderSnapshot) noexcept {};
         //-----------------------------------------
         /// Triggered when a state is the
         /// active state in the state manager and

--- a/Source/ChilliSource/Core/State/State.h
+++ b/Source/ChilliSource/Core/State/State.h
@@ -69,13 +69,13 @@ namespace ChilliSource
         ///
         /// @return A pointer to the main scene (that renders to screen).
         //----------------------------------------------------
-        Scene* GetScene();
+        Scene* GetMainScene() noexcept;
         //----------------------------------------------------
         /// @author Ian Copland
         ///
         /// @return A const pointer to the main scene (that renders to screen).
         //----------------------------------------------------
-        const Scene* GetScene() const;
+        const Scene* GetMainScene() const noexcept;
         //----------------------------------------------------
         /// @author S Downie
         ///
@@ -214,6 +214,8 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
+        /// @param targetType - Whether the snapshot is
+        /// for the main screen or an offscreen target
         /// @param renderSnapshot - The render
         /// snapshot object which contains all
         /// snapshotted data.
@@ -221,7 +223,7 @@ namespace ChilliSource
         /// any data required for rendering this frame
         /// from here
         //-----------------------------------------
-        void RenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
+        void RenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
         //-----------------------------------------
         /// Triggered when a state is the
         /// active state in the state manager and
@@ -316,6 +318,21 @@ namespace ChilliSource
         /// @param Fixed time since last update (Secs)
         //-----------------------------------------
         virtual void OnFixedUpdate(f32 in_deltaTime){};
+        
+        /// The render snapshot event can be implemented by a state to allow it to
+        /// snapshot any data which pertains to the renderer.
+        ///
+        /// @author Ian Copland
+        ///
+        /// @param targetType
+        ///     Whether the snapshot is for the main screen or offscreen
+        /// @param renderSnapshot
+        ///     The render snapshot object which contains all snapshotted data.
+        /// @param frameAllocator
+        ///     Use this to allocate any memory required for this frame
+        ///
+        virtual void OnRenderSnapshot(TargetType targetType, class RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept {};
+        
         //-----------------------------------------
         /// Triggered when a state is the
         /// active state in the state manager and

--- a/Source/ChilliSource/Core/State/StateManager.cpp
+++ b/Source/ChilliSource/Core/State/StateManager.cpp
@@ -321,11 +321,11 @@ namespace ChilliSource
     }
     //---------------------------------------------------------
     //---------------------------------------------------------
-    void StateManager::RenderSnapshotStates(RenderSnapshot& in_renderSnapshot) noexcept
+    void StateManager::RenderSnapshotStates(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         if(!m_states.empty())
         {
-            m_states.back()->RenderSnapshot(in_renderSnapshot);
+            m_states.back()->RenderSnapshot(renderSnapshot, frameAllocator);
         }
     }
     //---------------------------------------------------------

--- a/Source/ChilliSource/Core/State/StateManager.cpp
+++ b/Source/ChilliSource/Core/State/StateManager.cpp
@@ -321,11 +321,11 @@ namespace ChilliSource
     }
     //---------------------------------------------------------
     //---------------------------------------------------------
-    void StateManager::RenderSnapshotStates(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
+    void StateManager::RenderSnapshotStates(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         if(!m_states.empty())
         {
-            m_states.back()->RenderSnapshot(renderSnapshot, frameAllocator);
+            m_states.back()->RenderSnapshot(targetType, renderSnapshot, frameAllocator);
         }
     }
     //---------------------------------------------------------

--- a/Source/ChilliSource/Core/State/StateManager.h
+++ b/Source/ChilliSource/Core/State/StateManager.h
@@ -207,10 +207,12 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The render snapshot object
+        /// @param renderSnapshot - The render snapshot object
         /// which contains all snapshotted data.
+        /// @param frameAllocator - Allocate memory required for
+        /// rendering this frame from here
         //---------------------------------------------------------
-        void RenderSnapshotStates(RenderSnapshot& in_renderSnapshot) noexcept;
+        void RenderSnapshotStates(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
         //---------------------------------------------------------
         /// Triggered by the application when the system is
         /// pushed to the background. Forwards to states.

--- a/Source/ChilliSource/Core/State/StateManager.h
+++ b/Source/ChilliSource/Core/State/StateManager.h
@@ -207,12 +207,14 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
+        /// @param targetType - Whether the snapshot is for the main screen
+        /// or an offscreen target
         /// @param renderSnapshot - The render snapshot object
         /// which contains all snapshotted data.
         /// @param frameAllocator - Allocate memory required for
         /// rendering this frame from here
         //---------------------------------------------------------
-        void RenderSnapshotStates(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
+        void RenderSnapshotStates(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
         //---------------------------------------------------------
         /// Triggered by the application when the system is
         /// pushed to the background. Forwards to states.

--- a/Source/ChilliSource/Core/System/AppSystem.h
+++ b/Source/ChilliSource/Core/System/AppSystem.h
@@ -115,12 +115,14 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
+        /// @param targetType - Whether the snapshot is for the main
+        /// screen or an offscreen target
         /// @param renderSnapshot - The render snapshot
         /// object which contains all snapshotted data.
         /// @param frameAllocator - Allocate memory for
         /// this render frame from here
         //------------------------------------------------
-        virtual void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept {};
+        virtual void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept {};
         //------------------------------------------------
         /// Called when the application transitions from
         /// being active app into the background. This

--- a/Source/ChilliSource/Core/System/AppSystem.h
+++ b/Source/ChilliSource/Core/System/AppSystem.h
@@ -115,10 +115,12 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The render snapshot
+        /// @param renderSnapshot - The render snapshot
         /// object which contains all snapshotted data.
+        /// @param frameAllocator - Allocate memory for
+        /// this render frame from here
         //------------------------------------------------
-        virtual void OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept {};
+        virtual void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept {};
         //------------------------------------------------
         /// Called when the application transitions from
         /// being active app into the background. This

--- a/Source/ChilliSource/Core/System/StateSystem.h
+++ b/Source/ChilliSource/Core/System/StateSystem.h
@@ -117,10 +117,12 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The render snapshot
+        /// @param renderSnapshot - The render snapshot
         /// object which contains all snapshotted data.
+        /// @param frameAllocator - Allocate memory required
+        /// for rendering this frame from here
         //------------------------------------------------
-        virtual void OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept {};
+        virtual void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept {};
         //------------------------------------------------
         /// Called when the state transitions from
         /// being active app into the background. This

--- a/Source/ChilliSource/Core/System/StateSystem.h
+++ b/Source/ChilliSource/Core/System/StateSystem.h
@@ -117,12 +117,14 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
+        /// @param targetType - Whether the snapshot is for the
+        /// main screen or an offscreen render target
         /// @param renderSnapshot - The render snapshot
         /// object which contains all snapshotted data.
         /// @param frameAllocator - Allocate memory required
         /// for rendering this frame from here
         //------------------------------------------------
-        virtual void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept {};
+        virtual void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept {};
         //------------------------------------------------
         /// Called when the state transitions from
         /// being active app into the background. This

--- a/Source/ChilliSource/Rendering/Base.h
+++ b/Source/ChilliSource/Rendering/Base.h
@@ -62,6 +62,7 @@
 #include <ChilliSource/Rendering/Base/SizePolicy.h>
 #include <ChilliSource/Rendering/Base/SurfaceFormat.h>
 #include <ChilliSource/Rendering/Base/TargetRenderPassGroup.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 #include <ChilliSource/Rendering/Base/VerticalTextJustification.h>
 
 #endif

--- a/Source/ChilliSource/Rendering/Base/CanvasRenderer.cpp
+++ b/Source/ChilliSource/Rendering/Base/CanvasRenderer.cpp
@@ -36,6 +36,7 @@
 #include <ChilliSource/Core/State/StateManager.h>
 #include <ChilliSource/Core/String/UTF8StringUtils.h>
 #include <ChilliSource/Rendering/Base/RenderSnapshot.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 #include <ChilliSource/Rendering/Font/Font.h>
 #include <ChilliSource/Rendering/Material/Material.h>
 #include <ChilliSource/Rendering/Material/MaterialFactory.h>
@@ -782,24 +783,27 @@ namespace ChilliSource
     }
     //----------------------------------------------------------------------------
     //----------------------------------------------------------------------------
-    void CanvasRenderer::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
+    void CanvasRenderer::OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
-        auto activeState = CS::Application::Get()->GetStateManager()->GetActiveState();
-        CS_ASSERT(activeState, "must have active state.");
-        
-        auto activeUICanvas = activeState->GetUICanvas();
-        CS_ASSERT(activeUICanvas != nullptr, "Cannot render null UI canvas");
-        
-        m_currentRenderSnapshot = &renderSnapshot;
-        m_currentFrameAllocator = frameAllocator;
-        m_nextPriority = 0;
-        
-        activeUICanvas->Draw(this);
-        
-        m_currentFrameAllocator = nullptr;
-        m_currentRenderSnapshot = nullptr;
-        
-        m_materialPool->Clear();
+        if(targetType == TargetType::k_main)
+        {
+            auto activeState = CS::Application::Get()->GetStateManager()->GetActiveState();
+            CS_ASSERT(activeState, "must have active state.");
+            
+            auto activeUICanvas = activeState->GetUICanvas();
+            CS_ASSERT(activeUICanvas != nullptr, "Cannot render null UI canvas");
+            
+            m_currentRenderSnapshot = &renderSnapshot;
+            m_currentFrameAllocator = frameAllocator;
+            m_nextPriority = 0;
+            
+            activeUICanvas->Draw(this);
+            
+            m_currentFrameAllocator = nullptr;
+            m_currentRenderSnapshot = nullptr;
+            
+            m_materialPool->Clear();
+        }
     }
     //----------------------------------------------------------------------------
     //----------------------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/Base/CanvasRenderer.h
+++ b/Source/ChilliSource/Rendering/Base/CanvasRenderer.h
@@ -195,12 +195,14 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The render snapshot object which contains all
-        /// snapshotted data.
+        /// @param targetType
+        ///     Whether the snapshot is for the main screen or an offscreen render target
+        /// @param renderSnapshot
+        ///     The render snapshot object which contains all snapshotted data.
         /// @param frameAllocator
         ///     Allocate memory for this render frame from here
         //----------------------------------------------------------------------------
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
+        void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         //----------------------------------------------------------------------------
         /// Called when the system is destroyed
         ///

--- a/Source/ChilliSource/Rendering/Base/CanvasRenderer.h
+++ b/Source/ChilliSource/Rendering/Base/CanvasRenderer.h
@@ -197,8 +197,10 @@ namespace ChilliSource
         ///
         /// @param in_renderSnapshot - The render snapshot object which contains all
         /// snapshotted data.
+        /// @param frameAllocator
+        ///     Allocate memory for this render frame from here
         //----------------------------------------------------------------------------
-        void OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         //----------------------------------------------------------------------------
         /// Called when the system is destroyed
         ///
@@ -207,6 +209,7 @@ namespace ChilliSource
         void OnDestroy() override;
 
     private:
+        IAllocator* m_currentFrameAllocator = nullptr;
         RenderSnapshot* m_currentRenderSnapshot = nullptr;
         u32 m_nextPriority = 0;
         

--- a/Source/ChilliSource/Rendering/Base/ForwardRenderPassCompiler.cpp
+++ b/Source/ChilliSource/Rendering/Base/ForwardRenderPassCompiler.cpp
@@ -443,7 +443,14 @@ namespace ChilliSource
             
             taskContext.ProcessChildTasks(tasks);
             
-            return TargetRenderPassGroup(renderFrame.GetResolution(), renderFrame.GetClearColour(), std::move(cameraRenderPassGroups));
+            if(renderFrame.GetOffscreenRenderTarget() == nullptr)
+            {
+                return TargetRenderPassGroup(renderFrame.GetResolution(), renderFrame.GetClearColour(), std::move(cameraRenderPassGroups));
+            }
+            else
+            {
+                return TargetRenderPassGroup(renderFrame.GetOffscreenRenderTarget(), renderFrame.GetClearColour(), std::move(cameraRenderPassGroups));
+            }
         }
         
         /// Gather all render objects in the frame that are to be renderered into a shadow RenderTarget

--- a/Source/ChilliSource/Rendering/Base/ForwardRenderPassCompiler.h
+++ b/Source/ChilliSource/Rendering/Base/ForwardRenderPassCompiler.h
@@ -49,12 +49,12 @@ namespace ChilliSource
         ///
         /// @param taskContext
         ///     Context to manage any spawned tasks
-        /// @param renderFrame
+        /// @param renderFrames
         ///     Current frame data
         ///
         /// @return The list of target render pass groups
         ///
-        std::vector<TargetRenderPassGroup> CompileTargetRenderPassGroups(const TaskContext& taskContext, const RenderFrame& renderFrame) noexcept override;
+        std::vector<TargetRenderPassGroup> CompileTargetRenderPassGroups(const TaskContext& taskContext, std::vector<RenderFrame>&& renderFrames) noexcept override;
     };
 }
 

--- a/Source/ChilliSource/Rendering/Base/FrameAllocatorQueue.cpp
+++ b/Source/ChilliSource/Rendering/Base/FrameAllocatorQueue.cpp
@@ -60,6 +60,21 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
+    IAllocator* FrameAllocatorQueue::Front() noexcept
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        
+        while (m_queue.empty())
+        {
+            m_condition.wait(lock);
+        }
+        
+        auto front = m_queue.front();
+        
+        return front;
+    }
+    
+    //------------------------------------------------------------------------------
     void FrameAllocatorQueue::Push(IAllocator* allocator) noexcept
     {
         std::unique_lock<std::mutex> lock(m_mutex);

--- a/Source/ChilliSource/Rendering/Base/FrameAllocatorQueue.h
+++ b/Source/ChilliSource/Rendering/Base/FrameAllocatorQueue.h
@@ -58,6 +58,13 @@ namespace ChilliSource
         ///
         IAllocator* Pop() noexcept;
         
+        /// Reads the first frame allocator from the queue. If the queue is empty this will wait
+        /// until one is pushed before reading.
+        ///
+        /// @return The front frame allocator.
+        ///
+        IAllocator* Front() noexcept;
+        
         /// Pushes an allocator back into the queue for reuse. Prior to being added to the queue
         /// the allocator will be wiped.
         ///

--- a/Source/ChilliSource/Rendering/Base/IRenderPassCompiler.h
+++ b/Source/ChilliSource/Rendering/Base/IRenderPassCompiler.h
@@ -46,12 +46,12 @@ namespace ChilliSource
         ///
         /// @param taskContext
         ///     Context to manage any spawned tasks
-        /// @param renderFrame
+        /// @param renderFrames
         ///     Current frame data
         ///
         /// @return The list of target render pass groups
         ///
-        virtual std::vector<TargetRenderPassGroup> CompileTargetRenderPassGroups(const TaskContext& taskContext, const RenderFrame& renderFrame) noexcept = 0;
+        virtual std::vector<TargetRenderPassGroup> CompileTargetRenderPassGroups(const TaskContext& taskContext, std::vector<RenderFrame>&& renderFrame) noexcept = 0;
         
         virtual ~IRenderPassCompiler() noexcept {};
         

--- a/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.cpp
@@ -161,9 +161,9 @@ namespace ChilliSource
             RecycleCommandList(buffer->GetRenderCommandList(i));
         }
         
-//        auto frameAllocator = buffer->GetFrameAllocator();
-//        buffer.reset();
-//        m_renderer->GetFrameAllocatorQueue().Push(frameAllocator);
+        auto frameAllocator = buffer->GetFrameAllocator();
+        buffer.reset();
+        m_renderer->GetFrameAllocatorQueue().Push(frameAllocator);
     }
     //------------------------------------------------------------------------------
     void RenderCommandBufferManager::RecycleCommandList(RenderCommandList* renderCommandList) noexcept

--- a/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.cpp
@@ -27,6 +27,7 @@
 #include <ChilliSource/Core/Base/Application.h>
 #include <ChilliSource/Rendering/Base/Renderer.h>
 #include <ChilliSource/Rendering/Base/RenderSnapshot.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 #include <ChilliSource/Rendering/RenderCommand/Commands/LoadMaterialGroupRenderCommand.h>
 #include <ChilliSource/Rendering/RenderCommand/Commands/LoadMeshRenderCommand.h>
 #include <ChilliSource/Rendering/RenderCommand/Commands/LoadShaderRenderCommand.h>
@@ -94,9 +95,9 @@ namespace ChilliSource
         m_renderCommandBuffersCondition.notify_all();
     }
     //------------------------------------------------------------------------------
-    void RenderCommandBufferManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
+    void RenderCommandBufferManager::OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
-        if(!m_discardCommands)
+        if(!m_discardCommands && targetType == TargetType::k_main)
         {
             auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
             auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();

--- a/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.cpp
@@ -256,7 +256,7 @@ namespace ChilliSource
         m_renderCommandBuffersCondition.notify_all();
     }
     //------------------------------------------------------------------------------
-    std::vector<RenderCommandBufferCUPtr> RenderCommandBufferManager::WaitThenPopCommandBuffers() noexcept
+    RenderCommandBufferCUPtr RenderCommandBufferManager::WaitThenPopCommandBuffer() noexcept
     {
         std::unique_lock<std::mutex> lock(m_renderCommandBuffersMutex);
         
@@ -265,16 +265,11 @@ namespace ChilliSource
             m_renderCommandBuffersCondition.wait(lock);
         }
         
-        std::vector<RenderCommandBufferCUPtr> buffers(m_renderCommandBuffers.size());
-        
-        while (m_renderCommandBuffers.empty() == false)
-        {
-            buffers.push_back(std::move(m_renderCommandBuffers.front()));
-            m_renderCommandBuffers.pop_front();
-        }
+        auto buffer = std::move(m_renderCommandBuffers.front());
+        m_renderCommandBuffers.pop_front();
         
         m_renderCommandBuffersCondition.notify_all();
         
-        return buffers;
+        return std::move(buffer);
     }
 }

--- a/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.h
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.h
@@ -78,12 +78,12 @@ namespace ChilliSource
         ///
         void WaitThenPushCommandBuffer(RenderCommandBufferUPtr renderCommandBuffer) noexcept;
         
-        /// If the queue of command buffers is empty then this waits until one has been pushed to continue.
-        /// It pops a command buffer from the list and notifies any threads which are waiting.
+        /// If the queue of command buffers is empty then this waits until one or more has been pushed to continue.
+        /// It pops all command buffers from the list and notifies any threads which are waiting.
         ///
-        /// @return The render command buffer which has been popped.
+        /// @return The render command buffers which have been popped.
         ///
-        RenderCommandBufferCUPtr WaitThenPopCommandBuffer() noexcept;
+        std::vector<RenderCommandBufferCUPtr> WaitThenPopCommandBuffers() noexcept;
         
     private:
         friend class Application;
@@ -140,8 +140,10 @@ namespace ChilliSource
         ///
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
+        /// @param frameAllocator
+        ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         /// Called when the application delegate is suspended. This event is called directly
         /// from the platform application implementation and will be called before the lifecycle

--- a/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.h
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.h
@@ -78,12 +78,12 @@ namespace ChilliSource
         ///
         void WaitThenPushCommandBuffer(RenderCommandBufferUPtr renderCommandBuffer) noexcept;
         
-        /// If the queue of command buffers is empty then this waits until one or more has been pushed to continue.
-        /// It pops all command buffers from the list and notifies any threads which are waiting.
+        /// If the queue of command buffers is empty then this waits until one has been pushed to continue.
+        /// It pops the command buffer from the list and notifies any threads which are waiting.
         ///
-        /// @return The render command buffers which have been popped.
+        /// @return The render command buffer that has been popped.
         ///
-        std::vector<RenderCommandBufferCUPtr> WaitThenPopCommandBuffers() noexcept;
+        RenderCommandBufferCUPtr WaitThenPopCommandBuffer() noexcept;
         
     private:
         friend class Application;

--- a/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.h
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandBufferManager.h
@@ -138,12 +138,14 @@ namespace ChilliSource
         /// Called during the Render Snapshot stage of the render pipeline. All pending load commands
         /// are added to the render snapshot.
         ///
+        /// @param targetType
+        ///     Whether the snapshot is for the main screen or an offscreen render target
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
         /// @param frameAllocator
         ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
+        void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         /// Called when the application delegate is suspended. This event is called directly
         /// from the platform application implementation and will be called before the lifecycle

--- a/Source/ChilliSource/Rendering/Base/RenderCommandCompiler.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandCompiler.cpp
@@ -333,11 +333,11 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    RenderCommandBufferUPtr RenderCommandCompiler::CompileRenderCommands(const TaskContext& taskContext, const std::vector<TargetRenderPassGroup>& targetRenderPassGroups, RenderCommandListUPtr preRenderCommandList,
-                                                                          RenderCommandListUPtr postRenderCommandList, RenderFrameData renderFrameData) noexcept
+    RenderCommandBufferUPtr RenderCommandCompiler::CompileRenderCommands(const TaskContext& taskContext, IAllocator* frameAllocator, const std::vector<TargetRenderPassGroup>& targetRenderPassGroups, RenderCommandListUPtr preRenderCommandList,
+                                                                         RenderCommandListUPtr postRenderCommandList, std::vector<RenderFrameData>&& renderFramesData) noexcept
     {
         u32 numLists = CalcNumRenderCommandLists(targetRenderPassGroups, preRenderCommandList.get(), postRenderCommandList.get());
-        RenderCommandBufferUPtr renderCommandBuffer(new RenderCommandBuffer(numLists, std::move(renderFrameData)));
+        RenderCommandBufferUPtr renderCommandBuffer(new RenderCommandBuffer(numLists, frameAllocator, std::move(renderFramesData)));
         std::vector<Task> tasks;
         u32 currentList = 0;
         

--- a/Source/ChilliSource/Rendering/Base/RenderCommandCompiler.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandCompiler.cpp
@@ -334,7 +334,7 @@ namespace ChilliSource
     
     //------------------------------------------------------------------------------
     RenderCommandBufferUPtr RenderCommandCompiler::CompileRenderCommands(const TaskContext& taskContext, IAllocator* frameAllocator, const std::vector<TargetRenderPassGroup>& targetRenderPassGroups, RenderCommandListUPtr preRenderCommandList,
-                                                                         RenderCommandListUPtr postRenderCommandList, std::vector<RenderFrameData>&& renderFramesData) noexcept
+                                                                         RenderCommandListUPtr postRenderCommandList, std::vector<RenderFrameData> renderFramesData) noexcept
     {
         u32 numLists = CalcNumRenderCommandLists(targetRenderPassGroups, preRenderCommandList.get(), postRenderCommandList.get());
         RenderCommandBufferUPtr renderCommandBuffer(new RenderCommandBuffer(numLists, frameAllocator, std::move(renderFramesData)));

--- a/Source/ChilliSource/Rendering/Base/RenderCommandCompiler.h
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandCompiler.h
@@ -60,7 +60,7 @@ namespace ChilliSource
         /// @return The render command buffer.
         ///
         RenderCommandBufferUPtr CompileRenderCommands(const TaskContext& taskContext, IAllocator* frameAllocator, const std::vector<TargetRenderPassGroup>& targetRenderPassGroups, RenderCommandListUPtr preRenderCommandList,
-                                                      RenderCommandListUPtr postRenderCommandList, std::vector<RenderFrameData>&& renderFramesData) noexcept;
+                                                      RenderCommandListUPtr postRenderCommandList, std::vector<RenderFrameData> renderFramesData) noexcept;
     }
 }
 

--- a/Source/ChilliSource/Rendering/Base/RenderCommandCompiler.h
+++ b/Source/ChilliSource/Rendering/Base/RenderCommandCompiler.h
@@ -41,6 +41,8 @@ namespace ChilliSource
         /// render passes generated during the Compile Render Passes stage and breaks them down
         /// into a series of render commands. The output is an immutable render command buffer.
         ///
+        /// @param frameAllocator
+        ///     Allocator that was used to build this render frame
         /// @param taskContext
         ///     The task context that child tasks should be run within. This assumes that the
         ///     method is being called from within another task, as per the render pipeline
@@ -51,14 +53,14 @@ namespace ChilliSource
         ///     The RenderCommandList that should be included first. Must be moved.
         /// @param postRenderCommandList
         ///     The RenderCommandList that should be included last. Must be moved.
-        /// @param renderFrameData
-        ///     The container for all data allocated this frame that must persist to the end of the
+        /// @param renderFramesData
+        ///     List of containers for all data allocated this frame that must persist to the end of the
         ///     render pipeline. Must be moved.
         ///
         /// @return The render command buffer.
         ///
-        RenderCommandBufferUPtr CompileRenderCommands(const TaskContext& taskContext, const std::vector<TargetRenderPassGroup>& targetRenderPassGroups, RenderCommandListUPtr preRenderCommandList,
-                                                      RenderCommandListUPtr postRenderCommandList, RenderFrameData renderFrameData) noexcept;
+        RenderCommandBufferUPtr CompileRenderCommands(const TaskContext& taskContext, IAllocator* frameAllocator, const std::vector<TargetRenderPassGroup>& targetRenderPassGroups, RenderCommandListUPtr preRenderCommandList,
+                                                      RenderCommandListUPtr postRenderCommandList, std::vector<RenderFrameData>&& renderFramesData) noexcept;
     }
 }
 

--- a/Source/ChilliSource/Rendering/Base/RenderFrame.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderFrame.cpp
@@ -27,9 +27,9 @@
 namespace ChilliSource
 {
     //------------------------------------------------------------------------------
-    RenderFrame::RenderFrame(const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera, const AmbientRenderLight& renderAmbientLight,
+    RenderFrame::RenderFrame(const RenderTargetGroup* renderTarget, const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera, const AmbientRenderLight& renderAmbientLight,
                              const std::vector<DirectionalRenderLight>& renderDirectionalLights, const std::vector<PointRenderLight>& renderPointLights, const std::vector<RenderObject>& renderObjects) noexcept
-        : m_resolution(resolution), m_clearColour(clearColour), m_renderCamera(renderCamera), m_renderAmbientLight(renderAmbientLight), m_renderDirectionalLights(renderDirectionalLights),
+        : m_offscreenRenderTarget(renderTarget), m_resolution(resolution), m_clearColour(clearColour), m_renderCamera(renderCamera), m_renderAmbientLight(renderAmbientLight), m_renderDirectionalLights(renderDirectionalLights),
           m_renderPointLights(renderPointLights), m_renderObjects(renderObjects)
     {
     }

--- a/Source/ChilliSource/Rendering/Base/RenderFrame.h
+++ b/Source/ChilliSource/Rendering/Base/RenderFrame.h
@@ -45,6 +45,9 @@ namespace ChilliSource
     class RenderFrame final
     {
     public:
+        
+        RenderFrame() = default;
+        
         /// Creates a new instance with the given camera, lights and objects.
         ///
         /// @param renderTarget

--- a/Source/ChilliSource/Rendering/Base/RenderFrame.h
+++ b/Source/ChilliSource/Rendering/Base/RenderFrame.h
@@ -47,6 +47,8 @@ namespace ChilliSource
     public:
         /// Creates a new instance with the given camera, lights and objects.
         ///
+        /// @param renderTarget
+        ///     The render target to render into, if null renders to screen (frame buffer)
         /// @param resolution
         ///     The resolution of the viewport.
         /// @param clearColour
@@ -63,7 +65,7 @@ namespace ChilliSource
         /// @param renderObjects
         ///     A list of objects in the frame.
         ///
-        RenderFrame(const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera, const AmbientRenderLight& renderAmbientLight, const std::vector<DirectionalRenderLight>& renderDirectionalLights,
+        RenderFrame(const RenderTargetGroup* renderTarget, const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera, const AmbientRenderLight& renderAmbientLight, const std::vector<DirectionalRenderLight>& renderDirectionalLights,
                     const std::vector<PointRenderLight>& renderPointLights, const std::vector<RenderObject>& renderObjects) noexcept;
         
         /// @return The resolution of the viewport.
@@ -95,6 +97,10 @@ namespace ChilliSource
         ///
         const std::vector<RenderObject>& GetRenderObjects() const noexcept { return m_renderObjects; }
         
+        ///@return Render target for this frame, if null defaults to the frame buffer
+        ///
+        const RenderTargetGroup* GetOffscreenRenderTarget() const noexcept { return m_offscreenRenderTarget; }
+        
     private:
         Integer2 m_resolution;
         Colour m_clearColour;
@@ -103,6 +109,7 @@ namespace ChilliSource
         std::vector<DirectionalRenderLight> m_renderDirectionalLights;
         std::vector<PointRenderLight> m_renderPointLights;
         std::vector<RenderObject> m_renderObjects;
+        const RenderTargetGroup* m_offscreenRenderTarget;
     };
 }
 

--- a/Source/ChilliSource/Rendering/Base/RenderFrameCompiler.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderFrameCompiler.cpp
@@ -55,7 +55,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    RenderFrame RenderFrameCompiler::CompileRenderFrame(const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera, const std::vector<AmbientRenderLight>& renderAmbientLights,
+    RenderFrame RenderFrameCompiler::CompileRenderFrame(const RenderTargetGroup* renderTarget, const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera, const std::vector<AmbientRenderLight>& renderAmbientLights,
                                                         const std::vector<DirectionalRenderLight>& renderDirectionalLights, const std::vector<PointRenderLight>& renderPointLights,
                                                         const std::vector<RenderObject>& renderObjects) noexcept
     {
@@ -63,6 +63,6 @@ namespace ChilliSource
         
         auto renderAmbientLight = MergeAmbientRenderLights(renderAmbientLights);
         
-        return RenderFrame(resolution, clearColour, renderCamera, renderAmbientLight, renderDirectionalLights, renderPointLights, renderObjects);
+        return RenderFrame(renderTarget, resolution, clearColour, renderCamera, renderAmbientLight, renderDirectionalLights, renderPointLights, renderObjects);
     }
 }

--- a/Source/ChilliSource/Rendering/Base/RenderFrameCompiler.h
+++ b/Source/ChilliSource/Rendering/Base/RenderFrameCompiler.h
@@ -42,6 +42,8 @@ namespace ChilliSource
         /// a single immutable construct. During compilation all render jobs are performed
         /// to generate additional render primitives.
         ///
+        /// @param renderTarget
+        ///     The render target to render into, if null renders to screen (frame buffer)
         /// @param resolution
         ///     The resolution of the viewport.
         /// @param clearColour
@@ -59,7 +61,7 @@ namespace ChilliSource
         ///
         /// @return The compiled render frame.
         ///
-        RenderFrame CompileRenderFrame(const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera, const std::vector<AmbientRenderLight>& renderAmbientLights,
+        RenderFrame CompileRenderFrame(const RenderTargetGroup* renderTarget, const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera, const std::vector<AmbientRenderLight>& renderAmbientLights,
                                        const std::vector<DirectionalRenderLight>& renderDirectionalLights, const std::vector<PointRenderLight>& renderPointLights,
                                        const std::vector<RenderObject>& renderObjects) noexcept;
     }

--- a/Source/ChilliSource/Rendering/Base/RenderFrameData.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderFrameData.cpp
@@ -30,8 +30,7 @@ namespace ChilliSource
 {
     
     //------------------------------------------------------------------------------
-    RenderFrameData::RenderFrameData(IAllocator* frameAllocator) noexcept
-        : m_frameAllocator(frameAllocator)
+    RenderFrameData::RenderFrameData() noexcept
     {
     }
     

--- a/Source/ChilliSource/Rendering/Base/RenderFrameData.h
+++ b/Source/ChilliSource/Rendering/Base/RenderFrameData.h
@@ -47,17 +47,7 @@ namespace ChilliSource
         
         RenderFrameData(RenderFrameData&&) = default;
         RenderFrameData& operator=(RenderFrameData&&) = default;
-        
-        /// Creates a new instance with the given viewport resolution and clear colour.
-        ///
-        /// @param frameAllocator
-        ///     The allocator which should be used for all frame allocations.
-        ///
-        RenderFrameData(IAllocator* frameAllocator) noexcept;
-        
-        /// @return The allocator which should be used for all frame allocations.
-        ///
-        IAllocator* GetFrameAllocator() const noexcept { return m_frameAllocator; }
+        RenderFrameData() noexcept;
         
         /// Adds a RenderDynamicMesh. This will be deleted at the end of the frame.
         ///
@@ -74,7 +64,6 @@ namespace ChilliSource
         void AddRenderSkinnedAnimation(RenderSkinnedAnimationAUPtr renderSkinnedAnimation) noexcept;
         
     private:
-        IAllocator* m_frameAllocator;
         std::vector<RenderDynamicMeshAUPtr> m_renderDynamicMeshes;
         std::vector<RenderSkinnedAnimationAUPtr> m_renderSkinnedAnimations;
     };

--- a/Source/ChilliSource/Rendering/Base/RenderSnapshot.cpp
+++ b/Source/ChilliSource/Rendering/Base/RenderSnapshot.cpp
@@ -27,9 +27,9 @@
 namespace ChilliSource
 {
     //------------------------------------------------------------------------------
-    RenderSnapshot::RenderSnapshot(IAllocator* frameAllocator, const Integer2& resolution, const Colour& clearColour, const RenderCamera& in_renderCamera) noexcept
-        : m_resolution(resolution), m_clearColour(clearColour), m_renderCamera(in_renderCamera), m_preRenderCommandList(new RenderCommandList()), m_postRenderCommandList(new RenderCommandList()),
-          m_renderFrameData(frameAllocator)
+    RenderSnapshot::RenderSnapshot(const RenderTargetGroup* renderTarget, const Integer2& resolution, const Colour& clearColour, const RenderCamera& in_renderCamera) noexcept
+        : m_offscreenRenderTarget(renderTarget), m_resolution(resolution), m_clearColour(clearColour), m_renderCamera(in_renderCamera), m_preRenderCommandList(new RenderCommandList()), m_postRenderCommandList(new RenderCommandList()),
+          m_renderFrameData()
     {
     }
     

--- a/Source/ChilliSource/Rendering/Base/RenderSnapshot.h
+++ b/Source/ChilliSource/Rendering/Base/RenderSnapshot.h
@@ -60,8 +60,8 @@ namespace ChilliSource
         
         /// Creates a new instance with the given viewport resolution and clear colour.
         ///
-        /// @param frameAllocator
-        ///     The allocator which should be used for all frame allocations.
+        /// @param renderTarget
+        ///     The render target to render into, if null renders to screen (frame buffer)
         /// @param resolution
         ///     The viewport resolution.
         /// @param clearColour
@@ -70,11 +70,7 @@ namespace ChilliSource
         ///     The main camera that will be used to render the scene. Currently only one camera per
         ///     scene is supported.
         ///
-        RenderSnapshot(IAllocator* frameAllocator, const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera) noexcept;
-        
-        /// @return The allocator which should be used for all frame allocations.
-        ///
-        IAllocator* GetFrameAllocator() const noexcept { return m_renderFrameData.GetFrameAllocator(); }
+        RenderSnapshot(const RenderTargetGroup* renderTarget, const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera) noexcept;
         
         /// @return The viewport resolution.
         ///
@@ -180,6 +176,10 @@ namespace ChilliSource
         ///
         RenderFrameData ClaimRenderFrameData() noexcept;
         
+        ///@return Render target for this frame, if null defaults to the frame buffer
+        ///
+        const RenderTargetGroup* GetOffscreenRenderTarget() const noexcept { return m_offscreenRenderTarget; }
+        
     private:
         Integer2 m_resolution;
         Colour m_clearColour;
@@ -191,6 +191,7 @@ namespace ChilliSource
         RenderCommandListUPtr m_preRenderCommandList;
         RenderCommandListUPtr m_postRenderCommandList;
         RenderFrameData m_renderFrameData;
+        const RenderTargetGroup* m_offscreenRenderTarget;
         
         bool m_renderCameraClaimed = false;
         bool m_renderAmbientLightsClaimed = false;

--- a/Source/ChilliSource/Rendering/Base/Renderer.cpp
+++ b/Source/ChilliSource/Rendering/Base/Renderer.cpp
@@ -77,6 +77,7 @@ namespace ChilliSource
     {
         return (Renderer::InterfaceID == interfaceId);
     }
+    
     //------------------------------------------------------------------------------
     RenderSnapshot Renderer::CreateRenderSnapshot(const RenderTargetGroup* renderTarget, const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera) noexcept
     {

--- a/Source/ChilliSource/Rendering/Base/Renderer.cpp
+++ b/Source/ChilliSource/Rendering/Base/Renderer.cpp
@@ -85,7 +85,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void Renderer::ProcessRenderSnapshots(IAllocator*&& frameAllocator, RenderSnapshot&& mainRenderSnapshot, std::vector<RenderSnapshot>&& offscreenRenderSnapshots) noexcept
+    void Renderer::ProcessRenderSnapshots(IAllocator* frameAllocator, RenderSnapshot mainRenderSnapshot, std::vector<RenderSnapshot> offscreenRenderSnapshots) noexcept
     {
         WaitThenStartRenderPrep();
         
@@ -127,7 +127,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void Renderer::ProcessRenderCommandBuffers() noexcept
+    void Renderer::ProcessRenderCommandBuffer() noexcept
     {
         auto renderCommandBuffer = m_commandRecycleSystem->WaitThenPopCommandBuffer();
         m_renderCommandProcessor->Process(renderCommandBuffer.get());

--- a/Source/ChilliSource/Rendering/Base/Renderer.cpp
+++ b/Source/ChilliSource/Rendering/Base/Renderer.cpp
@@ -101,6 +101,8 @@ namespace ChilliSource
             
             for(auto i=0; i<m_currentOffscreenSnapshots.size(); ++i)
             {
+                CS_ASSERT(m_currentOffscreenSnapshots[i].GetPreRenderCommandList()->GetOrderedList().size() == 0 && m_currentOffscreenSnapshots[i].GetPostRenderCommandList()->GetOrderedList().size() == 0, "Offscreen render snapshots cannot have pre or post render commands");
+                
                 auto renderFrameData = m_currentOffscreenSnapshots[i].ClaimRenderFrameData();
                 renderFramesData.push_back(std::move(renderFrameData));
                 

--- a/Source/ChilliSource/Rendering/Base/Renderer.h
+++ b/Source/ChilliSource/Rendering/Base/Renderer.h
@@ -112,11 +112,16 @@ namespace ChilliSource
         ///
         /// This must be called from the main thread.
         ///
-        /// @param renderSnapshots
-        ///     The render snapshots to process. They should have already been populated by passing it
+        /// @param frameAllocator
+        ///     Allocator used to allocate the render snapshots that should be released when the frame is rendererd
+        /// @param mainRenderSnapshot
+        ///     The render snapshot to process for the main scene. This should have already been populated by passing it
         ///     to each system and component in the scene. This must be moved.
+        /// @param offscreenRenderSnapshots
+        ///     The render snapshots to process for offscreen targets. They should have already been populated by passing them
+        ///     to each system and component in the scene. They must be moved.
         ///
-        void ProcessRenderSnapshots(std::vector<RenderSnapshot>&& renderSnapshots) noexcept;
+        void ProcessRenderSnapshots(IAllocator*&& frameAllocator, RenderSnapshot&& mainRenderSnapshot, std::vector<RenderSnapshot>&& offscreenRenderSnapshots) noexcept;
         
         /// Processes the next render command buffers. If there are no render command buffers ready to be
         /// processed then this will block until there is.
@@ -180,7 +185,8 @@ namespace ChilliSource
         bool m_renderPrepActive = false;
         bool m_initialised = false;
         
-        std::vector<RenderSnapshot> m_currentSnapshots;
+        RenderSnapshot m_currentMainSnapshot;
+        std::vector<RenderSnapshot> m_currentOffscreenSnapshots;
         
         RenderCommandBufferManager* m_commandRecycleSystem = nullptr;
     };

--- a/Source/ChilliSource/Rendering/Base/Renderer.h
+++ b/Source/ChilliSource/Rendering/Base/Renderer.h
@@ -121,14 +121,14 @@ namespace ChilliSource
         ///     The render snapshots to process for offscreen targets. They should have already been populated by passing them
         ///     to each system and component in the scene. They must be moved.
         ///
-        void ProcessRenderSnapshots(IAllocator*&& frameAllocator, RenderSnapshot&& mainRenderSnapshot, std::vector<RenderSnapshot>&& offscreenRenderSnapshots) noexcept;
+        void ProcessRenderSnapshots(IAllocator* frameAllocator, RenderSnapshot mainRenderSnapshot, std::vector<RenderSnapshot> offscreenRenderSnapshots) noexcept;
         
-        /// Processes the next render command buffers. If there are no render command buffers ready to be
+        /// Processes the next render command buffer. If there is no render command buffer ready to be
         /// processed then this will block until there is.
         ///
         /// This must be called from the render thread.
         ///
-        void ProcessRenderCommandBuffers() noexcept;
+        void ProcessRenderCommandBuffer() noexcept;
         
         /// @return The renderers frame allocator queue
         ///

--- a/Source/ChilliSource/Rendering/Base/Renderer.h
+++ b/Source/ChilliSource/Rendering/Base/Renderer.h
@@ -89,6 +89,8 @@ namespace ChilliSource
         /// scene. This will be created with the next queued frame allocator; if one isn't available
         /// this will block until one is.
         ///
+        /// @param renderTarget
+        ///     The render target to render into, if null renders to screen (frame buffer)
         /// @param resolution
         ///     The viewport resolution.
         /// @param clearColour
@@ -99,7 +101,7 @@ namespace ChilliSource
         ///
         /// @return The new render snapshot object.
         ///
-        RenderSnapshot CreateRenderSnapshot(const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera) noexcept;
+        RenderSnapshot CreateRenderSnapshot(const RenderTargetGroup* renderTarget, const Integer2& resolution, const Colour& clearColour, const RenderCamera& renderCamera) noexcept;
         
         /// Performs the Scene Snapshot through to the Render Command Queue Compilation Stages and
         /// then stores the output render command buffer render to later be processed by the
@@ -110,18 +112,18 @@ namespace ChilliSource
         ///
         /// This must be called from the main thread.
         ///
-        /// @param renderSnapshot
-        ///     The render snapshot to process. This should have already been populated by passing it
+        /// @param renderSnapshots
+        ///     The render snapshots to process. They should have already been populated by passing it
         ///     to each system and component in the scene. This must be moved.
         ///
-        void ProcessRenderSnapshot(RenderSnapshot renderSnapshot) noexcept;
+        void ProcessRenderSnapshots(std::vector<RenderSnapshot>&& renderSnapshots) noexcept;
         
-        /// Processes the next render command buffer. If there is no render command buffer ready to be
+        /// Processes the next render command buffers. If there are no render command buffers ready to be
         /// processed then this will block until there is.
         ///
         /// This must be called from the render thread.
         ///
-        void ProcessRenderCommandBuffer() noexcept;
+        void ProcessRenderCommandBuffers() noexcept;
         
         /// @return The renderers frame allocator queue
         ///
@@ -173,12 +175,12 @@ namespace ChilliSource
         IRenderPassCompilerUPtr m_renderPassCompiler;
         IRenderCommandProcessorUPtr m_renderCommandProcessor;
         
-        RenderSnapshot m_currentSnapshot;
-        
         std::mutex m_renderPrepMutex;
         std::condition_variable m_renderPrepCondition;
         bool m_renderPrepActive = false;
         bool m_initialised = false;
+        
+        std::vector<RenderSnapshot> m_currentSnapshots;
         
         RenderCommandBufferManager* m_commandRecycleSystem = nullptr;
     };

--- a/Source/ChilliSource/Rendering/Base/TargetType.h
+++ b/Source/ChilliSource/Rendering/Base/TargetType.h
@@ -22,32 +22,16 @@
 //  THE SOFTWARE.
 //
 
-#include <ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.h>
+#ifndef _CHILLISOURCE_RENDERING_BASE_TARGETTYPE_H_
+#define _CHILLISOURCE_RENDERING_BASE_TARGETTYPE_H_
 
 namespace ChilliSource
 {
-    //------------------------------------------------------------------------------
-    RenderCommandBuffer::RenderCommandBuffer(u32 numSlots, IAllocator* frameAllocator, std::vector<RenderFrameData> renderFramesData) noexcept
-        : m_renderFramesData(std::move(renderFramesData)), m_frameAllocator(frameAllocator)
+    enum class TargetType
     {
-        m_renderCommandLists.reserve(numSlots);
-        for (u32 i = 0; i < numSlots; ++i)
-        {
-            m_renderCommandLists.push_back(RenderCommandListUPtr(new RenderCommandList()));
-        }
-        
-        m_queue.reserve(numSlots);
-        for (const auto& renderCommandList : m_renderCommandLists)
-        {
-            m_queue.push_back(renderCommandList.get());
-        }
-    }
-    
-    //------------------------------------------------------------------------------
-    RenderCommandList* RenderCommandBuffer::GetRenderCommandList(u32 slotIndex) noexcept
-    {
-        CS_ASSERT(slotIndex < GetNumSlots(), "Index out of bounds.");
-        
-        return m_renderCommandLists[slotIndex].get();
-    }
+        k_main,
+        k_offscreen
+    };
 }
+
+#endif

--- a/Source/ChilliSource/Rendering/ForwardDeclarations.h
+++ b/Source/ChilliSource/Rendering/ForwardDeclarations.h
@@ -64,6 +64,7 @@ namespace ChilliSource
     enum class RenderLayer;
     enum class SizePolicy;
     enum class SurfaceFormat;
+    enum class TargetType;
     enum class VerticalTextJustification;
     //------------------------------------------------------------
     /// Camera

--- a/Source/ChilliSource/Rendering/Lighting/AmbientLightComponent.cpp
+++ b/Source/ChilliSource/Rendering/Lighting/AmbientLightComponent.cpp
@@ -44,7 +44,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void AmbientLightComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void AmbientLightComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         renderSnapshot.AddAmbientRenderLight(AmbientRenderLight(GetFinalColour()));
     }

--- a/Source/ChilliSource/Rendering/Lighting/AmbientLightComponent.h
+++ b/Source/ChilliSource/Rendering/Lighting/AmbientLightComponent.h
@@ -86,10 +86,12 @@ namespace ChilliSource
         /// the current state of the renderable portion of the scene. This will add all relevant light
         /// data to this snapshot.
         ///
-        /// @return renderSnapshot
+        /// @param renderSnapshot
         ///     The snapshot that the light data will be added to.
+        /// @param frameAllocator
+        ///     Allocate any render memory for this frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         Colour m_colour;
         f32 m_intensity;

--- a/Source/ChilliSource/Rendering/Lighting/DirectionalLightComponent.cpp
+++ b/Source/ChilliSource/Rendering/Lighting/DirectionalLightComponent.cpp
@@ -120,7 +120,7 @@ namespace ChilliSource
         {
             auto mutableShadowMap = Application::Get()->GetResourcePool()->CreateResource<Texture>("_DirectionalLightShadowMap" + ToString(m_shadowMapId));
             
-            TextureDesc desc(m_shadowMapResolution, ImageFormat::k_Depth16, ImageCompression::k_none);
+            TextureDesc desc(m_shadowMapResolution, ImageFormat::k_Depth16, ImageCompression::k_none, false);
             mutableShadowMap->Build(nullptr, 0, desc);
             mutableShadowMap->SetLoadState(Resource::LoadState::k_loaded);
             

--- a/Source/ChilliSource/Rendering/Lighting/DirectionalLightComponent.cpp
+++ b/Source/ChilliSource/Rendering/Lighting/DirectionalLightComponent.cpp
@@ -167,7 +167,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void DirectionalLightComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void DirectionalLightComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         if (m_shadowMap)
         {

--- a/Source/ChilliSource/Rendering/Lighting/DirectionalLightComponent.h
+++ b/Source/ChilliSource/Rendering/Lighting/DirectionalLightComponent.h
@@ -168,10 +168,13 @@ namespace ChilliSource
         /// the current state of the renderable portion of the scene. This will add all relevant light
         /// data to this snapshot.
         ///
+        /// @param renderSnapshot - Add anything to this that must be captured for rendering
+        /// @param frameAllocator - Allocate any memory required for rendering from this
+        ///
         /// @return renderSnapshot
         ///     The snapshot that the light data will be added to.
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         /// Triggered when either the component is removed from an entity which is currently in the
         /// scene, or the owning entity is removed from the scene.

--- a/Source/ChilliSource/Rendering/Lighting/PointLightComponent.cpp
+++ b/Source/ChilliSource/Rendering/Lighting/PointLightComponent.cpp
@@ -105,7 +105,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void PointLightComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void PointLightComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         renderSnapshot.AddPointRenderLight(PointRenderLight(GetFinalColour(), m_lightPosition, m_attenuation, m_rangeOfInfluence));
     }

--- a/Source/ChilliSource/Rendering/Lighting/PointLightComponent.h
+++ b/Source/ChilliSource/Rendering/Lighting/PointLightComponent.h
@@ -141,10 +141,12 @@ namespace ChilliSource
         /// the current state of the renderable portion of the scene. This will add all relevant light
         /// data to this snapshot.
         ///
-        /// @return renderSnapshot
+        /// @param renderSnapshot
         ///     The snapshot that the light data will be added to.
+        /// @param frameAllocator
+        ///     Allocate any memory for rendering this frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         /// Triggered when either the component is removed from an entity which is currently in the
         /// scene, or the owning entity is removed from the scene.

--- a/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.cpp
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.cpp
@@ -69,7 +69,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void RenderMaterialGroupManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void RenderMaterialGroupManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
         auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();

--- a/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.cpp
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.cpp
@@ -25,6 +25,7 @@
 #include <ChilliSource/Rendering/Material/RenderMaterialGroupManager.h>
 
 #include <ChilliSource/Rendering/Base/RenderSnapshot.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 #include <ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.h>
 #include <ChilliSource/Rendering/RenderCommand/RenderCommandList.h>
 
@@ -69,24 +70,27 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void RenderMaterialGroupManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
+    void RenderMaterialGroupManager::OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
-        auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
-        auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();
-        
-        std::unique_lock<std::mutex> lock(m_mutex);
-        
-        for (auto& loadCommand : m_pendingLoadCommands)
+        if(targetType == TargetType::k_main)
         {
-            preRenderCommandList->AddLoadMaterialGroupCommand(loadCommand);
+            auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
+            auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();
+            
+            std::unique_lock<std::mutex> lock(m_mutex);
+            
+            for (auto& loadCommand : m_pendingLoadCommands)
+            {
+                preRenderCommandList->AddLoadMaterialGroupCommand(loadCommand);
+            }
+            m_pendingLoadCommands.clear();
+            
+            for (auto& unloadCommand : m_pendingUnloadCommands)
+            {
+                postRenderCommandList->AddUnloadMaterialGroupCommand(std::move(unloadCommand));
+            }
+            m_pendingUnloadCommands.clear();
         }
-        m_pendingLoadCommands.clear();
-        
-        for (auto& unloadCommand : m_pendingUnloadCommands)
-        {
-            postRenderCommandList->AddUnloadMaterialGroupCommand(std::move(unloadCommand));
-        }
-        m_pendingUnloadCommands.clear();
     }
     
     //------------------------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.h
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.h
@@ -181,8 +181,10 @@ namespace ChilliSource
         ///
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
+        /// @param frameAllocator
+        ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderMaterialGroupUPtr> m_renderMaterialGroups;

--- a/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.h
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.h
@@ -179,12 +179,14 @@ namespace ChilliSource
         /// Called during the Render Snapshot stage of the render pipeline. All pending load and
         /// unload commands are added to the render snapshot.
         ///
+        /// @param targetType
+        ///     Whether the snapshot is for the main screen or an offscreen render target
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
         /// @param frameAllocator
         ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
+        void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderMaterialGroupUPtr> m_renderMaterialGroups;

--- a/Source/ChilliSource/Rendering/Model/AnimatedModelComponent.cpp
+++ b/Source/ChilliSource/Rendering/Model/AnimatedModelComponent.cpp
@@ -622,7 +622,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void AnimatedModelComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void AnimatedModelComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         CS_ASSERT(m_model->GetLoadState() == Resource::LoadState::k_loaded, "Cannot use a model that hasn't been loaded yet.");
         CS_ASSERT(m_model->GetNumMeshes() == m_materials.size(), "Invalid number of materials.");
@@ -646,11 +646,11 @@ namespace ChilliSource
             RenderSkinnedAnimationAUPtr renderSkinnedAnimation;
             if (m_activeAnimationGroup->IsPrepared() == true)
             {
-                renderSkinnedAnimation = m_activeAnimationGroup->BuildRenderSkinnedAnimation(renderSnapshot.GetFrameAllocator(), renderMesh->GetInverseBindPoseMatrices());
+                renderSkinnedAnimation = m_activeAnimationGroup->BuildRenderSkinnedAnimation(frameAllocator, renderMesh->GetInverseBindPoseMatrices());
             }
             else if (m_fadingAnimationGroup != nullptr && m_fadingAnimationGroup->IsPrepared() == true)
             {
-                renderSkinnedAnimation = m_fadingAnimationGroup->BuildRenderSkinnedAnimation(renderSnapshot.GetFrameAllocator(), renderMesh->GetInverseBindPoseMatrices());
+                renderSkinnedAnimation = m_fadingAnimationGroup->BuildRenderSkinnedAnimation(frameAllocator, renderMesh->GetInverseBindPoseMatrices());
             }
             
             CS_ASSERT(renderSkinnedAnimation, "No render skinned animation.");

--- a/Source/ChilliSource/Rendering/Model/AnimatedModelComponent.h
+++ b/Source/ChilliSource/Rendering/Model/AnimatedModelComponent.h
@@ -530,8 +530,10 @@ namespace ChilliSource
         ///
         /// @param renderSnapshot
         ///     The render snapshot.
+        /// @param frameAllocator - Use this to allocate any memory
+        /// for this render frame
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         /// Triggered when the component is removed to the scene.
         ///

--- a/Source/ChilliSource/Rendering/Model/RenderMeshManager.cpp
+++ b/Source/ChilliSource/Rendering/Model/RenderMeshManager.cpp
@@ -88,7 +88,7 @@ namespace ChilliSource
     }
 
     //------------------------------------------------------------------------------
-    void RenderMeshManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void RenderMeshManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
         auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();

--- a/Source/ChilliSource/Rendering/Model/RenderMeshManager.h
+++ b/Source/ChilliSource/Rendering/Model/RenderMeshManager.h
@@ -135,12 +135,14 @@ namespace ChilliSource
         /// Called during the Render Snapshot stage of the render pipeline. All pending load and
         /// unload commands are added to the render snapshot.
         ///
+        /// @param targetType
+        ///     Whether the snapshot is for the main screen or an offscreen render target
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
         /// @param frameAllocator
         ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
+        void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderMeshUPtr> m_renderMeshes; //TODO: This should be changed to an object pool.

--- a/Source/ChilliSource/Rendering/Model/RenderMeshManager.h
+++ b/Source/ChilliSource/Rendering/Model/RenderMeshManager.h
@@ -137,8 +137,10 @@ namespace ChilliSource
         ///
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
+        /// @param frameAllocator
+        ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderMeshUPtr> m_renderMeshes; //TODO: This should be changed to an object pool.

--- a/Source/ChilliSource/Rendering/Model/StaticModelComponent.cpp
+++ b/Source/ChilliSource/Rendering/Model/StaticModelComponent.cpp
@@ -333,7 +333,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void StaticModelComponent::OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept
+    void StaticModelComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         CS_ASSERT(m_model->GetLoadState() == Resource::LoadState::k_loaded, "Cannot use a model that hasn't been loaded yet.");
         CS_ASSERT(m_model->GetNumMeshes() == m_materials.size(), "Invalid number of materials.");
@@ -348,7 +348,7 @@ namespace ChilliSource
             const auto& transform = GetEntity()->GetTransform();
             auto boundingSphere = Sphere::Transform(renderMesh->GetBoundingSphere(), transform.GetWorldPosition(), transform.GetWorldScale());
             
-            in_renderSnapshot.AddRenderObject(RenderObject(renderMaterialGroup, renderMesh, GetEntity()->GetTransform().GetWorldTransform(), boundingSphere, m_shadowCastingEnabled, RenderLayer::k_standard));
+            renderSnapshot.AddRenderObject(RenderObject(renderMaterialGroup, renderMesh, GetEntity()->GetTransform().GetWorldTransform(), boundingSphere, m_shadowCastingEnabled, RenderLayer::k_standard));
         }
     }
     

--- a/Source/ChilliSource/Rendering/Model/StaticModelComponent.h
+++ b/Source/ChilliSource/Rendering/Model/StaticModelComponent.h
@@ -203,8 +203,10 @@ namespace ChilliSource
         ///
         /// @param renderSnapshot
         ///     The render snapshot.
+        /// @param frameAllocator
+        ///     Allocate any memory required for rendering stuff from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         /// Triggered when the component is removed from an entity on the scene.
         ///

--- a/Source/ChilliSource/Rendering/Particle/Drawable/ParticleDrawable.cpp
+++ b/Source/ChilliSource/Rendering/Particle/Drawable/ParticleDrawable.cpp
@@ -40,7 +40,7 @@ namespace ChilliSource
     }
     //----------------------------------------------------------------
     //----------------------------------------------------------------
-    void ParticleDrawable::Draw(RenderSnapshot& in_renderSnapshot) noexcept
+    void ParticleDrawable::Draw(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         m_concurrentParticleData->Lock();
 
@@ -50,7 +50,7 @@ namespace ChilliSource
             ActivateParticle(m_concurrentParticleData->GetParticles(), index);
         }
 
-        DrawParticles(m_concurrentParticleData->GetParticles(), in_renderSnapshot);
+        DrawParticles(m_concurrentParticleData->GetParticles(), renderSnapshot, frameAllocator);
 
         m_concurrentParticleData->Unlock();
     }

--- a/Source/ChilliSource/Rendering/Particle/Drawable/ParticleDrawable.h
+++ b/Source/ChilliSource/Rendering/Particle/Drawable/ParticleDrawable.h
@@ -68,10 +68,12 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The render snapshot that particles
+        /// @param renderSnapshot - The render snapshot that particles
         /// will be added to.
+        /// @param frameAllocator - Allocate memory for this render frame
+        /// from here
         //----------------------------------------------------------------
-        void Draw(RenderSnapshot& in_renderSnapshot) noexcept;
+        void Draw(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept;
         //----------------------------------------------------------------
         /// Destructor
         ///
@@ -115,8 +117,10 @@ namespace ChilliSource
         /// @param in_particleData - The particle draw data.
         /// @param in_renderSnapshot - The render snapshot that particles
         /// will be added to.
+        /// @param frameAllocator - Allocate memory for this render frame
+        /// from here
         //----------------------------------------------------------------
-        virtual void DrawParticles(const dynamic_array<ConcurrentParticleData::Particle>& in_particleData, RenderSnapshot& in_renderSnapshot) = 0;
+        virtual void DrawParticles(const dynamic_array<ConcurrentParticleData::Particle>& particleData, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) = 0;
         
     private:
         const Entity* m_entity = nullptr;

--- a/Source/ChilliSource/Rendering/Particle/Drawable/StaticBillboardParticleDrawable.cpp
+++ b/Source/ChilliSource/Rendering/Particle/Drawable/StaticBillboardParticleDrawable.cpp
@@ -121,15 +121,15 @@ namespace ChilliSource
     }
     //----------------------------------------------------------------
     //----------------------------------------------------------------
-    void StaticBillboardParticleDrawable::DrawParticles(const dynamic_array<ConcurrentParticleData::Particle>& in_particleData, RenderSnapshot& in_renderSnapshot)
+    void StaticBillboardParticleDrawable::DrawParticles(const dynamic_array<ConcurrentParticleData::Particle>& particleData, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator)
     {
         switch (GetDrawableDef()->GetParticleEffect()->GetSimulationSpace())
         {
         case ParticleEffect::SimulationSpace::k_local:
-            DrawLocalSpace(in_particleData, in_renderSnapshot);
+            DrawLocalSpace(particleData, renderSnapshot, frameAllocator);
             break;
         case ParticleEffect::SimulationSpace::k_world:
-            DrawWorldSpace(in_particleData, in_renderSnapshot);
+            DrawWorldSpace(particleData, renderSnapshot, frameAllocator);
             break;
         default:
             CS_LOG_FATAL("Invalid simulation space.");
@@ -183,7 +183,7 @@ namespace ChilliSource
     }
     //----------------------------------------------------------------
     //----------------------------------------------------------------
-    void StaticBillboardParticleDrawable::DrawLocalSpace(const dynamic_array<ConcurrentParticleData::Particle>& in_particleData, RenderSnapshot& in_renderSnapshot) const
+    void StaticBillboardParticleDrawable::DrawLocalSpace(const dynamic_array<ConcurrentParticleData::Particle>& particleData, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) const
     {
         auto renderMaterialGroup = m_billboardDrawableDef->GetMaterial()->GetRenderMaterialGroup();
         auto entityWorldTransform = GetEntity()->GetTransform().GetWorldTransform();
@@ -195,11 +195,11 @@ namespace ChilliSource
         f32 particleScaleFactor = (entityScale.x + entityScale.y + entityScale.z) / 3.0f;
 
         //billboard by applying the inverse of the view orientation. The view orientation is the inverse of the camera entity orientation.
-        auto inverseView = in_renderSnapshot.GetRenderCamera().GetOrientation();
+        auto inverseView = renderSnapshot.GetRenderCamera().GetOrientation();
 
-        for (u32 i = 0; i < in_particleData.size(); ++i)
+        for (u32 i = 0; i < particleData.size(); ++i)
         {
-            const auto& particle = in_particleData[i];
+            const auto& particle = particleData[i];
 
             if (particle.m_isActive == true && particle.m_colour != Colour::k_transparent)
             {
@@ -210,27 +210,27 @@ namespace ChilliSource
                 auto worldOrientation = Quaternion(Vector3::k_unitPositiveZ, particle.m_rotation) * inverseView; //rotate locally in the XY plane before rotating to face the camera.
                 auto worldMatrix = Matrix4::CreateTransform(worldPosition, worldScale, worldOrientation);
                 
-                auto renderDynamicMesh = SpriteMeshBuilder::Build(in_renderSnapshot.GetFrameAllocator(), Vector3(billboardData.m_localCentre, 0.0f), billboardData.m_localSize, billboardData.m_uvs,
+                auto renderDynamicMesh = SpriteMeshBuilder::Build(frameAllocator, Vector3(billboardData.m_localCentre, 0.0f), billboardData.m_localSize, billboardData.m_uvs,
                                                                   particle.m_colour, AlignmentAnchor::k_middleCentre);
                 auto worldBoundingSphere = Sphere::Transform(renderDynamicMesh->GetBoundingSphere(), worldPosition, worldScale);
                 
-                in_renderSnapshot.AddRenderObject(RenderObject(renderMaterialGroup, renderDynamicMesh.get(), worldMatrix, worldBoundingSphere, false, RenderLayer::k_standard));
-                in_renderSnapshot.AddRenderDynamicMesh(std::move(renderDynamicMesh));
+                renderSnapshot.AddRenderObject(RenderObject(renderMaterialGroup, renderDynamicMesh.get(), worldMatrix, worldBoundingSphere, false, RenderLayer::k_standard));
+                renderSnapshot.AddRenderDynamicMesh(std::move(renderDynamicMesh));
             }
         }
     }
     //----------------------------------------------------------------
     //----------------------------------------------------------------
-    void StaticBillboardParticleDrawable::DrawWorldSpace(const dynamic_array<ConcurrentParticleData::Particle>& in_particleData, RenderSnapshot& in_renderSnapshot) const
+    void StaticBillboardParticleDrawable::DrawWorldSpace(const dynamic_array<ConcurrentParticleData::Particle>& particleData, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) const
     {
         auto renderMaterialGroup = m_billboardDrawableDef->GetMaterial()->GetRenderMaterialGroup();
 
         //billboard by applying the inverse of the view orientation. The view orientation is the inverse of the camera entity orientation.
-        auto inverseView = in_renderSnapshot.GetRenderCamera().GetOrientation();
+        auto inverseView = renderSnapshot.GetRenderCamera().GetOrientation();
 
-        for (u32 i = 0; i < in_particleData.size(); ++i)
+        for (u32 i = 0; i < particleData.size(); ++i)
         {
-            const auto& particle = in_particleData[i];
+            const auto& particle = particleData[i];
 
             if (particle.m_isActive == true && particle.m_colour != Colour::k_transparent)
             {
@@ -241,12 +241,12 @@ namespace ChilliSource
                 auto worldOrientation = Quaternion(Vector3::k_unitPositiveZ, particle.m_rotation) * inverseView;  //rotate locally in the XY plane before rotating to face the camera.
                 auto worldMatrix = Matrix4::CreateTransform(worldPosition, worldScale, worldOrientation);
 
-                auto renderDynamicMesh = SpriteMeshBuilder::Build(in_renderSnapshot.GetFrameAllocator(), Vector3(billboardData.m_localCentre, 0.0f), billboardData.m_localSize, billboardData.m_uvs,
+                auto renderDynamicMesh = SpriteMeshBuilder::Build(frameAllocator, Vector3(billboardData.m_localCentre, 0.0f), billboardData.m_localSize, billboardData.m_uvs,
                                                                   particle.m_colour, AlignmentAnchor::k_middleCentre);
                 auto worldBoundingSphere = Sphere::Transform(renderDynamicMesh->GetBoundingSphere(), worldPosition, worldScale);
                 
-                in_renderSnapshot.AddRenderObject(RenderObject(renderMaterialGroup, renderDynamicMesh.get(), worldMatrix, worldBoundingSphere, false, RenderLayer::k_standard));
-                in_renderSnapshot.AddRenderDynamicMesh(std::move(renderDynamicMesh));
+                renderSnapshot.AddRenderObject(RenderObject(renderMaterialGroup, renderDynamicMesh.get(), worldMatrix, worldBoundingSphere, false, RenderLayer::k_standard));
+                renderSnapshot.AddRenderDynamicMesh(std::move(renderDynamicMesh));
             }
         }
     }

--- a/Source/ChilliSource/Rendering/Particle/Drawable/StaticBillboardParticleDrawable.h
+++ b/Source/ChilliSource/Rendering/Particle/Drawable/StaticBillboardParticleDrawable.h
@@ -82,11 +82,13 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param The particle draw data.
-        /// @param in_renderSnapshot - The render snapshot that particles
+        /// @param particleData - The particle draw data.
+        /// @param renderSnapshot - The render snapshot that particles
         /// will be added to.
+        /// @param frameAllocator - Allocate memory for this render frame
+        /// from here
         //----------------------------------------------------------------
-        void DrawParticles(const dynamic_array<ConcurrentParticleData::Particle>& in_particleData, RenderSnapshot& in_renderSnapshot) override;
+        void DrawParticles(const dynamic_array<ConcurrentParticleData::Particle>& particleData, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) override;
         //----------------------------------------------------------------
         /// Builds the billboard image data from the provided texture
         /// or texture atlas.
@@ -108,11 +110,13 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param The particle draw data.
-        /// @param in_renderSnapshot - The render snapshot that particles
+        /// @param particleData - The particle draw data.
+        /// @param renderSnapshot - The render snapshot that particles
         /// will be added to.
+        /// @param frameAllocator - Allocate memory for this render frame
+        /// from here
         //----------------------------------------------------------------
-        void DrawLocalSpace(const dynamic_array<ConcurrentParticleData::Particle>& in_particleData, RenderSnapshot& in_renderSnapshot) const;
+        void DrawLocalSpace(const dynamic_array<ConcurrentParticleData::Particle>& particleData, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) const;
         //----------------------------------------------------------------
         /// Draws the particles without taking into account the world
         /// space transform of the owning entity as the particles are
@@ -120,11 +124,13 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param The particle draw data.
-        /// @param in_renderSnapshot - The render snapshot that particles
+        /// @param particleData - The particle draw data.
+        /// @param renderSnapshot - The render snapshot that particles
         /// will be added to.
+        /// @param frameAllocator - Allocate memory for this render frame
+        /// from here
         //----------------------------------------------------------------
-        void DrawWorldSpace(const dynamic_array<ConcurrentParticleData::Particle>& in_particleData, RenderSnapshot& in_renderSnapshot) const;
+        void DrawWorldSpace(const dynamic_array<ConcurrentParticleData::Particle>& particleData, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) const;
 
         const StaticBillboardParticleDrawableDef* m_billboardDrawableDef;
         std::unique_ptr <dynamic_array<BillboardData>> m_billboards;

--- a/Source/ChilliSource/Rendering/Particle/ParticleEffectComponent.cpp
+++ b/Source/ChilliSource/Rendering/Particle/ParticleEffectComponent.cpp
@@ -636,13 +636,13 @@ namespace ChilliSource
     }
     //----------------------------------------------------------------
     //----------------------------------------------------------------
-    void ParticleEffectComponent::OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept
+    void ParticleEffectComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         if (m_particleEffect != nullptr && (m_playbackState == PlaybackState::k_playing || m_playbackState == PlaybackState::k_stopping))
         {
             CS_ASSERT(m_drawable != nullptr, "Cannot render without a drawable.");
             
-            m_drawable->Draw(in_renderSnapshot);
+            m_drawable->Draw(renderSnapshot, frameAllocator);
         }
     }
     //----------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/Particle/ParticleEffectComponent.h
+++ b/Source/ChilliSource/Rendering/Particle/ParticleEffectComponent.h
@@ -358,9 +358,13 @@ namespace ChilliSource
         /// to acquire all render primitives in the scene. This adds new
         /// render objects for each a particle in the effect.
         ///
+        /// @param renderSnapshot - Add anything to this that must be
+        ///     captured for this frame
+        /// @param frameAllocator - Allocate any memory for this frame from here
+        ///
         /// @author Ian Copland
         //----------------------------------------------------------------
-        void OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         //----------------------------------------------------------------
         /// Called when the entities transform changes. This invalidates
         /// the bounding shape cache.

--- a/Source/ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.cpp
+++ b/Source/ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.cpp
@@ -27,8 +27,8 @@
 namespace ChilliSource
 {
     //------------------------------------------------------------------------------
-    RenderCommandBuffer::RenderCommandBuffer(u32 numSlots, RenderFrameData renderFrameData) noexcept
-        : m_renderFrameData(std::move(renderFrameData))
+    RenderCommandBuffer::RenderCommandBuffer(u32 numSlots, IAllocator* frameAllocator, std::vector<RenderFrameData>&& renderFramesData) noexcept
+        : m_renderFramesData(std::move(renderFramesData)), m_frameAllocator(frameAllocator)
     {
         m_renderCommandLists.reserve(numSlots);
         for (u32 i = 0; i < numSlots; ++i)

--- a/Source/ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.h
+++ b/Source/ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.h
@@ -62,10 +62,6 @@ namespace ChilliSource
         ///
         RenderCommandBuffer(u32 numSlots, RenderFrameData renderFrameData) noexcept;
         
-        /// @return The allocator from which all frame allocations should occur.
-        ///
-        IAllocator* GetFrameAllocator() const noexcept { return m_renderFrameData.GetFrameAllocator(); }
-        
         /// @return The number of slots in the queue.
         ///
         u32 GetNumSlots() const noexcept { return u32(m_queue.size()); }

--- a/Source/ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.h
+++ b/Source/ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.h
@@ -62,7 +62,7 @@ namespace ChilliSource
         /// @param renderFramesData
         ///     The render frame data that must persist to the end of the frame. Must be moved.
         ///
-        RenderCommandBuffer(u32 numSlots, IAllocator* frameAllocator, std::vector<RenderFrameData>&& renderFramesData) noexcept;
+        RenderCommandBuffer(u32 numSlots, IAllocator* frameAllocator, std::vector<RenderFrameData> renderFramesData) noexcept;
         
         /// @return The allocator from which all frame allocations should occur.
         ///

--- a/Source/ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.h
+++ b/Source/ChilliSource/Rendering/RenderCommand/RenderCommandBuffer.h
@@ -57,10 +57,16 @@ namespace ChilliSource
         ///
         /// @param numSlots
         ///     The number of slots in the queue.
-        /// @param renderFrameData
+        /// @param frameAllocator
+        ///     The allocator used for this render frame
+        /// @param renderFramesData
         ///     The render frame data that must persist to the end of the frame. Must be moved.
         ///
-        RenderCommandBuffer(u32 numSlots, RenderFrameData renderFrameData) noexcept;
+        RenderCommandBuffer(u32 numSlots, IAllocator* frameAllocator, std::vector<RenderFrameData>&& renderFramesData) noexcept;
+        
+        /// @return The allocator from which all frame allocations should occur.
+        ///
+        IAllocator* GetFrameAllocator() const noexcept { return m_frameAllocator; }
         
         /// @return The number of slots in the queue.
         ///
@@ -82,7 +88,8 @@ namespace ChilliSource
         std::vector<RenderSkinnedAnimationAUPtr> m_renderSkinnedAnimations;
         std::vector<const RenderCommandList*> m_queue;
         std::vector<RenderCommandListUPtr> m_renderCommandLists; //TODO: This should be changed to a pool.
-        const RenderFrameData m_renderFrameData;
+        const std::vector<RenderFrameData> m_renderFramesData;
+        IAllocator* m_frameAllocator;
     };
 }
 

--- a/Source/ChilliSource/Rendering/Shader/RenderShaderManager.cpp
+++ b/Source/ChilliSource/Rendering/Shader/RenderShaderManager.cpp
@@ -81,7 +81,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void RenderShaderManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void RenderShaderManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
         auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();

--- a/Source/ChilliSource/Rendering/Shader/RenderShaderManager.cpp
+++ b/Source/ChilliSource/Rendering/Shader/RenderShaderManager.cpp
@@ -25,6 +25,7 @@
 #include <ChilliSource/Rendering/Shader/RenderShaderManager.h>
 
 #include <ChilliSource/Rendering/Base/RenderSnapshot.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 
 namespace ChilliSource
 {
@@ -81,24 +82,27 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void RenderShaderManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
+    void RenderShaderManager::OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
-        auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
-        auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();
-        
-        std::unique_lock<std::mutex> lock(m_mutex);
-        
-        for (auto& loadCommand : m_pendingLoadCommands)
+        if(targetType == TargetType::k_main)
         {
-            preRenderCommandList->AddLoadShaderCommand(loadCommand.m_renderShader, loadCommand.m_vertexShader, loadCommand.m_fragmentShader);
+            auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
+            auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();
+            
+            std::unique_lock<std::mutex> lock(m_mutex);
+            
+            for (auto& loadCommand : m_pendingLoadCommands)
+            {
+                preRenderCommandList->AddLoadShaderCommand(loadCommand.m_renderShader, loadCommand.m_vertexShader, loadCommand.m_fragmentShader);
+            }
+            m_pendingLoadCommands.clear();
+            
+            for (auto& unloadCommand : m_pendingUnloadCommands)
+            {
+                postRenderCommandList->AddUnloadShaderCommand(std::move(unloadCommand));
+            }
+            m_pendingUnloadCommands.clear();
         }
-        m_pendingLoadCommands.clear();
-        
-        for (auto& unloadCommand : m_pendingUnloadCommands)
-        {
-            postRenderCommandList->AddUnloadShaderCommand(std::move(unloadCommand));
-        }
-        m_pendingUnloadCommands.clear();
     }
     
     //------------------------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/Shader/RenderShaderManager.h
+++ b/Source/ChilliSource/Rendering/Shader/RenderShaderManager.h
@@ -111,12 +111,14 @@ namespace ChilliSource
         /// Called during the Render Snapshot stage of the render pipeline. All pending load and
         /// unload commands are added to the render snapshot.
         ///
+        /// @param targetType
+        ///     Whether the snapshot is for the main screen or an offscreen render target
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
         /// @param frameAllocator
         ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
+        void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderShaderUPtr> m_renderShaders; //TODO: This should be changed to an object pool.

--- a/Source/ChilliSource/Rendering/Shader/RenderShaderManager.h
+++ b/Source/ChilliSource/Rendering/Shader/RenderShaderManager.h
@@ -113,8 +113,10 @@ namespace ChilliSource
         ///
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
+        /// @param frameAllocator
+        ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderShaderUPtr> m_renderShaders; //TODO: This should be changed to an object pool.

--- a/Source/ChilliSource/Rendering/Sprite/SpriteComponent.cpp
+++ b/Source/ChilliSource/Rendering/Sprite/SpriteComponent.cpp
@@ -434,7 +434,7 @@ namespace ChilliSource
     }
     //------------------------------------------------------------
     //------------------------------------------------------------
-    void SpriteComponent::OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept
+    void SpriteComponent::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         Vector2 frameCenter;
         Vector2 frameSize;
@@ -464,10 +464,10 @@ namespace ChilliSource
         }
         
         const auto& transform = GetEntity()->GetTransform();
-        auto renderDynamicMesh = SpriteMeshBuilder::Build(in_renderSnapshot.GetFrameAllocator(), Vector3(frameCenter, 0.0f), frameSize, transformedUVs, m_colour, m_originAlignment);
+        auto renderDynamicMesh = SpriteMeshBuilder::Build(frameAllocator, Vector3(frameCenter, 0.0f), frameSize, transformedUVs, m_colour, m_originAlignment);
         auto boundingSphere = Sphere::Transform(renderDynamicMesh->GetBoundingSphere(), transform.GetWorldPosition(), transform.GetWorldScale());
-        in_renderSnapshot.AddRenderObject(RenderObject(GetMaterial()->GetRenderMaterialGroup(), renderDynamicMesh.get(), transform.GetWorldTransform(), boundingSphere, false, RenderLayer::k_standard));
-        in_renderSnapshot.AddRenderDynamicMesh(std::move(renderDynamicMesh));
+        renderSnapshot.AddRenderObject(RenderObject(GetMaterial()->GetRenderMaterialGroup(), renderDynamicMesh.get(), transform.GetWorldTransform(), boundingSphere, false, RenderLayer::k_standard));
+        renderSnapshot.AddRenderDynamicMesh(std::move(renderDynamicMesh));
     }
     //----------------------------------------------------
     //----------------------------------------------------

--- a/Source/ChilliSource/Rendering/Sprite/SpriteComponent.h
+++ b/Source/ChilliSource/Rendering/Sprite/SpriteComponent.h
@@ -292,10 +292,12 @@ namespace ChilliSource
         ///
         /// @author Ian Copland
         ///
-        /// @param in_renderSnapshot - The snapshot containing all
+        /// @param renderSnapshot - The snapshot containing all
         /// data pertaining to a single frame.
+        /// @param frameAllocator - Use this to allocate any memory
+        /// for this render frame
         //------------------------------------------------------------
-        void OnRenderSnapshot(RenderSnapshot& in_renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         //------------------------------------------------------------
         /// Triggered when the component is removed from an entity on
         /// the scene

--- a/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.cpp
+++ b/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.cpp
@@ -123,7 +123,7 @@ namespace ChilliSource
     }
 
     //------------------------------------------------------------------------------
-    void RenderTargetGroupManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void RenderTargetGroupManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
         auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();

--- a/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.cpp
+++ b/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.cpp
@@ -25,6 +25,7 @@
 #include <ChilliSource/Rendering/Target/RenderTargetGroupManager.h>
 
 #include <ChilliSource/Rendering/Base/RenderSnapshot.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 
 namespace ChilliSource
 {
@@ -123,24 +124,27 @@ namespace ChilliSource
     }
 
     //------------------------------------------------------------------------------
-    void RenderTargetGroupManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
+    void RenderTargetGroupManager::OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
-        auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
-        auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();
-        
-        std::unique_lock<std::mutex> lock(m_mutex);
-        
-        for (auto& loadCommand : m_pendingLoadCommands)
+        if(targetType == TargetType::k_main)
         {
-            preRenderCommandList->AddLoadTargetGroupCommand(loadCommand);
+            auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
+            auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();
+            
+            std::unique_lock<std::mutex> lock(m_mutex);
+            
+            for (auto& loadCommand : m_pendingLoadCommands)
+            {
+                preRenderCommandList->AddLoadTargetGroupCommand(loadCommand);
+            }
+            m_pendingLoadCommands.clear();
+            
+            for (auto& unloadCommand : m_pendingUnloadCommands)
+            {
+                postRenderCommandList->AddUnloadTargetGroupCommand(std::move(unloadCommand));
+            }
+            m_pendingUnloadCommands.clear();
         }
-        m_pendingLoadCommands.clear();
-        
-        for (auto& unloadCommand : m_pendingUnloadCommands)
-        {
-            postRenderCommandList->AddUnloadTargetGroupCommand(std::move(unloadCommand));
-        }
-        m_pendingUnloadCommands.clear();
     }
     
     //------------------------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.h
+++ b/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.h
@@ -135,12 +135,14 @@ namespace ChilliSource
         /// Called during the Render Snapshot stage of the render pipeline. All pending load and
         /// unload commands are added to the render snapshot.
         ///
+        /// @param targetType
+        ///     Whether the snapshot is for the main screen or an offscreen render target
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
         /// @param frameAllocator
         ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
+        void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderTargetGroupUPtr> m_renderTargetGroups; //TODO: This should be changed to an object pool.

--- a/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.h
+++ b/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.h
@@ -137,8 +137,10 @@ namespace ChilliSource
         ///
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
+        /// @param frameAllocator
+        ///     Allocate memory for this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderTargetGroupUPtr> m_renderTargetGroups; //TODO: This should be changed to an object pool.

--- a/Source/ChilliSource/Rendering/Texture/RenderTextureManager.cpp
+++ b/Source/ChilliSource/Rendering/Texture/RenderTextureManager.cpp
@@ -82,7 +82,7 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void RenderTextureManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept
+    void RenderTextureManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
         auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
         auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();

--- a/Source/ChilliSource/Rendering/Texture/RenderTextureManager.cpp
+++ b/Source/ChilliSource/Rendering/Texture/RenderTextureManager.cpp
@@ -25,6 +25,7 @@
 #include <ChilliSource/Rendering/Texture/RenderTextureManager.h>
 
 #include <ChilliSource/Rendering/Base/RenderSnapshot.h>
+#include <ChilliSource/Rendering/Base/TargetType.h>
 
 namespace ChilliSource
 {
@@ -82,24 +83,27 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    void RenderTextureManager::OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
+    void RenderTextureManager::OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept
     {
-        auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
-        auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();
-        
-        std::unique_lock<std::mutex> lock(m_mutex);
-        
-        for (auto& loadCommand : m_pendingLoadCommands)
+        if(targetType == TargetType::k_main)
         {
-            preRenderCommandList->AddLoadTextureCommand(loadCommand.m_renderTexture, std::move(loadCommand.m_textureData), loadCommand.m_textureDataSize);
+            auto preRenderCommandList = renderSnapshot.GetPreRenderCommandList();
+            auto postRenderCommandList = renderSnapshot.GetPostRenderCommandList();
+            
+            std::unique_lock<std::mutex> lock(m_mutex);
+            
+            for (auto& loadCommand : m_pendingLoadCommands)
+            {
+                preRenderCommandList->AddLoadTextureCommand(loadCommand.m_renderTexture, std::move(loadCommand.m_textureData), loadCommand.m_textureDataSize);
+            }
+            m_pendingLoadCommands.clear();
+            
+            for (auto& unloadCommand : m_pendingUnloadCommands)
+            {
+                postRenderCommandList->AddUnloadTextureCommand(std::move(unloadCommand));
+            }
+            m_pendingUnloadCommands.clear();
         }
-        m_pendingLoadCommands.clear();
-        
-        for (auto& unloadCommand : m_pendingUnloadCommands)
-        {
-            postRenderCommandList->AddUnloadTextureCommand(std::move(unloadCommand));
-        }
-        m_pendingUnloadCommands.clear();
     }
     
     //------------------------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/Texture/RenderTextureManager.h
+++ b/Source/ChilliSource/Rendering/Texture/RenderTextureManager.h
@@ -128,12 +128,14 @@ namespace ChilliSource
         /// Called during the Render Snapshot stage of the render pipeline. All pending load and
         /// unload commands are added to the render snapshot.
         ///
+        /// @param targetType
+        ///     Whether the snapshot is for the main screen or an offscreen render target
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
         /// @param frameAllocator
         ///     Allocate memory from this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
+        void OnRenderSnapshot(TargetType targetType, RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderTextureUPtr> m_renderTextures; //TODO: This should be changed to an object pool.

--- a/Source/ChilliSource/Rendering/Texture/RenderTextureManager.h
+++ b/Source/ChilliSource/Rendering/Texture/RenderTextureManager.h
@@ -130,8 +130,10 @@ namespace ChilliSource
         ///
         /// @param renderSnapshot
         ///     The render shapshot for storing snapshotted data.
+        /// @param frameAllocator
+        ///     Allocate memory from this render frame from here
         ///
-        void OnRenderSnapshot(RenderSnapshot& renderSnapshot) noexcept override;
+        void OnRenderSnapshot(RenderSnapshot& renderSnapshot, IAllocator* frameAllocator) noexcept override;
         
         std::mutex m_mutex;
         std::vector<RenderTextureUPtr> m_renderTextures; //TODO: This should be changed to an object pool.

--- a/Source/ChilliSource/Rendering/Texture/TextureDesc.cpp
+++ b/Source/ChilliSource/Rendering/Texture/TextureDesc.cpp
@@ -40,9 +40,10 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    TextureDesc::TextureDesc(const Integer2& dimensions, ImageFormat imageFormat, ImageCompression imageCompression) noexcept
+    TextureDesc::TextureDesc(const Integer2& dimensions, ImageFormat imageFormat, ImageCompression imageCompression, bool restorable) noexcept
         : m_dimensions(dimensions), m_imageFormat(imageFormat), m_imageCompression(imageCompression)
     {
+        SetTextureDataRestoreEnabled(restorable);
     }
 
     //------------------------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/Texture/TextureDesc.h
+++ b/Source/ChilliSource/Rendering/Texture/TextureDesc.h
@@ -52,8 +52,10 @@ namespace ChilliSource
         ///     The format of the image.
         /// @param imageCompression
         ///     The compression type applied to the texture data.
+        /// @param restorable
+        ///     Whether or not the texture is restored automatically after context loss
         ///
-        TextureDesc(const Integer2& dimensions, ImageFormat imageFormat, ImageCompression imageCompression) noexcept;
+        TextureDesc(const Integer2& dimensions, ImageFormat imageFormat, ImageCompression imageCompression, bool restorable) noexcept;
         
         /// Sets the texture filter mode that will be used when rendering the texture.
         ///
@@ -82,21 +84,6 @@ namespace ChilliSource
         ///     Whether or not the texture should be mipmapped.
         ///
         void SetMipmappingEnabled(bool mipmappingEnabled) noexcept { m_mipmappingEnabled = mipmappingEnabled; };
-        
-        /// Sets whether or not the texture data should be restored after a context loss. This involves
-        /// maintaining a copy of the texture data in memory which is costly so this should be disabled
-        /// for any textures that can easily be recreated, i.e any texture that is rendered into every
-        /// frame.
-        ///
-        /// This has no effect on textures that are loaded from file as they are always restored from
-        /// disk.
-        ///
-        /// This will only work for RGBA8888, RGB888, RGBA4444 and RGB565 textures.
-        ///
-        /// @param restoreTextureDataEnabled
-        ///     Whether or not texture data should be restored on context loss.
-        ///
-        void SetTextureDataRestoreEnabled(bool restoreTextureDataEnabled) noexcept;
         
         /// @return The texture dimensions.
         ///
@@ -129,6 +116,23 @@ namespace ChilliSource
         /// @return Whether or not texture data should be restored on context loss.
         ///
         bool IsRestoreTextureDataEnabled() const noexcept { return m_restoreTextureDataEnabled; }
+        
+    private:
+        
+        /// Sets whether or not the texture data should be restored after a context loss. This involves
+        /// maintaining a copy of the texture data in memory which is costly so this should be disabled
+        /// for any textures that can easily be recreated, i.e any texture that is rendered into every
+        /// frame.
+        ///
+        /// This has no effect on textures that are loaded from file as they are always restored from
+        /// disk.
+        ///
+        /// This will only work for RGBA8888, RGB888, RGBA4444 and RGB565 textures.
+        ///
+        /// @param restoreTextureDataEnabled
+        ///     Whether or not texture data should be restored on context loss.
+        ///
+        void SetTextureDataRestoreEnabled(bool restoreTextureDataEnabled) noexcept;
         
     private:
         Integer2 m_dimensions;

--- a/Source/ChilliSource/Rendering/Texture/TextureProvider.cpp
+++ b/Source/ChilliSource/Rendering/Texture/TextureProvider.cpp
@@ -165,12 +165,11 @@ namespace ChilliSource
             auto texture = static_cast<Texture*>(out_resource.get());
             auto options = static_cast<const TextureResourceOptions*>(in_options.get());
             
-            TextureDesc desc(Integer2(image->GetWidth(), image->GetHeight()), image->GetFormat(), image->GetCompression());
+            TextureDesc desc(Integer2(image->GetWidth(), image->GetHeight()), image->GetFormat(), image->GetCompression(), false);
             desc.SetFilterMode(options->GetFilterMode());
             desc.SetWrapModeS(options->GetWrapModeS());
             desc.SetWrapModeT(options->GetWrapModeT());
             desc.SetMipmappingEnabled(options->IsMipMapsEnabled());
-            desc.SetTextureDataRestoreEnabled(false);
 
             texture->Build(Texture::DataUPtr(image->MoveData()), image->GetDataSize(), desc);
             texture->SetLoadState(Resource::LoadState::k_loaded);
@@ -182,12 +181,11 @@ namespace ChilliSource
                 auto texture = static_cast<Texture*>(out_resource.get());
                 auto options = static_cast<const TextureResourceOptions*>(in_options.get());
 
-                TextureDesc desc(Integer2(image->GetWidth(), image->GetHeight()), image->GetFormat(), image->GetCompression());
+                TextureDesc desc(Integer2(image->GetWidth(), image->GetHeight()), image->GetFormat(), image->GetCompression(), false);
                 desc.SetFilterMode(options->GetFilterMode());
                 desc.SetWrapModeS(options->GetWrapModeS());
                 desc.SetWrapModeT(options->GetWrapModeT());
                 desc.SetMipmappingEnabled(options->IsMipMapsEnabled());
-                desc.SetTextureDataRestoreEnabled(false);
 
                 texture->Build(Texture::DataUPtr(image->MoveData()), image->GetDataSize(), desc);
                 texture->SetLoadState(Resource::LoadState::k_loaded);


### PR DESCRIPTION
Render to texture has been re-introduced to work with the new renderer.

* Application has a RenderScene method which takes a snapshot and caches it for processing with the main snapshot
* States can now have multiple scenes as long as only one of them renders to screen, the other must be given a render target.
* The image data for context restoring is now updated rather than just captured initially.

Usage example found in the equivalent feature branch on CSTest but essentially:
* To render a scene every frame to a render target: create a scene using the state system, pass in a render target.

* To render a scene only once to a render target: create a scene using the state system, pass in a render target, call disable on the scene to prevent auto rendering and manually call RenderScene on application passing in the scene.

* To render the main scene to a render target, create a render target and call RenderScene on application passing in the main scene and the render target

![img_0101](https://cloud.githubusercontent.com/assets/6662661/17062911/c176fdc4-502c-11e6-9dee-799afdd6e452.PNG)

