### PR TITLE
UI Masking (child clipping)

### DIFF
--- a/CSResources/Shaders/Sprite-UnlitStencil.csshader
+++ b/CSResources/Shaders/Sprite-UnlitStencil.csshader
@@ -73,7 +73,9 @@ GLSL
 		void main()
 		{
 			gl_FragColor = texture2D(u_texture0, vvTexCoord) * vvColour;
-			if(gl_FragColor.a == 0.0)
+
+			//Pick a small alpha test value for pixels that are invisble to the eye
+			if(gl_FragColor.a < 0.05)
 			{
 				discard;
 			}

--- a/CSResources/Shaders/Sprite-UnlitStencil.csshader
+++ b/CSResources/Shaders/Sprite-UnlitStencil.csshader
@@ -1,0 +1,83 @@
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2014 Tag Games Limited
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+GLSL
+{
+	VertexShader
+	{
+		#ifndef GL_ES
+		#define lowp
+		#define mediump
+		#define highp
+		#endif
+
+		//attributes
+		attribute highp vec4 a_position;
+		attribute lowp vec4 a_colour;
+		attribute mediump vec2 a_texCoord;
+
+		//uniforms
+		uniform highp mat4 u_wvpMat;
+		uniform lowp vec4 u_emissive;
+
+		//varyings
+		varying lowp vec4 vvColour;
+		varying mediump vec2 vvTexCoord;
+
+		void main()
+		{
+		    gl_Position = u_wvpMat * a_position;
+		    vvColour = a_colour * u_emissive;
+		    vvTexCoord = a_texCoord;
+		}
+	}
+	
+	FragmentShader
+	{
+		#ifndef GL_ES
+		#define lowp
+		#define mediump
+		#define highp
+		#else
+		precision lowp float;
+		#endif
+
+		//uniforms
+		uniform lowp sampler2D u_texture0;
+
+		//varyings
+		varying lowp vec4 vvColour;
+		varying mediump vec2 vvTexCoord;
+
+		void main()
+		{
+			gl_FragColor = texture2D(u_texture0, vvTexCoord) * vvColour;
+			if(gl_FragColor.a == 0.0)
+			{
+				discard;
+			}
+		}
+	}
+}
+

--- a/Projects/Windows/ChilliSource.vcxproj
+++ b/Projects/Windows/ChilliSource.vcxproj
@@ -610,8 +610,10 @@
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\RenderPassVisibilityChecker.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\RenderSnapshot.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\SizePolicy.h" />
+    <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\StencilOp.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\SurfaceFormat.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\TargetRenderPassGroup.h" />
+    <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\TestFunc.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\VerticalTextJustification.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Camera.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Camera\CameraComponent.h" />

--- a/Projects/Windows/ChilliSource.vcxproj
+++ b/Projects/Windows/ChilliSource.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="..\..\Source\ChilliSource\Rendering\Base\AlignmentAnchors.cpp" />
     <ClCompile Include="..\..\Source\ChilliSource\Rendering\Base\AspectRatioUtils.cpp" />
     <ClCompile Include="..\..\Source\ChilliSource\Rendering\Base\CameraRenderPassGroup.cpp" />
+    <ClCompile Include="..\..\Source\ChilliSource\Rendering\Base\CanvasDrawMode.cpp" />
     <ClCompile Include="..\..\Source\ChilliSource\Rendering\Base\CanvasMaterialPool.cpp" />
     <ClCompile Include="..\..\Source\ChilliSource\Rendering\Base\CanvasRenderer.cpp" />
     <ClCompile Include="..\..\Source\ChilliSource\Rendering\Base\ForwardRenderPassCompiler.cpp" />
@@ -584,6 +585,7 @@
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\AspectRatioUtils.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\BlendMode.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\CameraRenderPassGroup.h" />
+    <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\CanvasDrawMode.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\CanvasMaterialPool.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\CanvasRenderer.h" />
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\CullFace.h" />

--- a/Projects/Windows/ChilliSource.vcxproj.filters
+++ b/Projects/Windows/ChilliSource.vcxproj.filters
@@ -1335,6 +1335,9 @@
     <ClCompile Include="..\..\Source\ChilliSource\Core\Base\RenderInfo.cpp">
       <Filter>ChilliSource\Core\Base</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\ChilliSource\Rendering\Base\CanvasDrawMode.cpp">
+      <Filter>ChilliSource\Rendering\Base</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Source\ChilliSource\Audio\CricketAudio\CkAudioPlayer.h">
@@ -2832,6 +2835,9 @@
       <Filter>ChilliSource\Rendering\Base</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\TestFunc.h">
+      <Filter>ChilliSource\Rendering\Base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\CanvasDrawMode.h">
       <Filter>ChilliSource\Rendering\Base</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Projects/Windows/ChilliSource.vcxproj.filters
+++ b/Projects/Windows/ChilliSource.vcxproj.filters
@@ -2828,5 +2828,11 @@
     <ClInclude Include="..\..\Source\ChilliSource\Core\Base\RenderInfo.h">
       <Filter>ChilliSource\Core\Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\StencilOp.h">
+      <Filter>ChilliSource\Rendering\Base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\ChilliSource\Rendering\Base\TestFunc.h">
+      <Filter>ChilliSource\Rendering\Base</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Projects/iOS/ChilliSource.xcodeproj/project.pbxproj
+++ b/Projects/iOS/ChilliSource.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 		81C7FFD71C89DDE300D306F9 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81C7FFBF1C89DDE300D306F9 /* StoreKit.framework */; };
 		81C7FFD81C89DDE300D306F9 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81C7FFC01C89DDE300D306F9 /* SystemConfiguration.framework */; };
 		81C7FFD91C89DDE300D306F9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81C7FFC11C89DDE300D306F9 /* UIKit.framework */; };
+		81EB41181D48B3E9005A7CE9 /* CanvasDrawMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 81EB41171D48B3E9005A7CE9 /* CanvasDrawMode.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1357,6 +1358,8 @@
 		81C7FFC11C89DDE300D306F9 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		81EB410D1D460C99005A7CE9 /* StencilOp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StencilOp.h; sourceTree = "<group>"; };
 		81EB410E1D461267005A7CE9 /* TestFunc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestFunc.h; sourceTree = "<group>"; };
+		81EB41161D48AEFD005A7CE9 /* CanvasDrawMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasDrawMode.h; sourceTree = "<group>"; };
+		81EB41171D48B3E9005A7CE9 /* CanvasDrawMode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasDrawMode.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2499,6 +2502,8 @@
 				81845F7B1D3503E8004B0C46 /* BlendMode.h */,
 				81845F7C1D3503E8004B0C46 /* CameraRenderPassGroup.cpp */,
 				81845F7D1D3503E8004B0C46 /* CameraRenderPassGroup.h */,
+				81EB41171D48B3E9005A7CE9 /* CanvasDrawMode.cpp */,
+				81EB41161D48AEFD005A7CE9 /* CanvasDrawMode.h */,
 				81845F7E1D3503E8004B0C46 /* CanvasMaterialPool.cpp */,
 				81845F7F1D3503E8004B0C46 /* CanvasMaterialPool.h */,
 				81845F801D3503E8004B0C46 /* CanvasRenderer.cpp */,
@@ -3774,6 +3779,7 @@
 				818461E51D3503E8004B0C46 /* RenderMaterialGroupManager.cpp in Sources */,
 				8158F7C71C89D2AD00B13109 /* DialogueBoxSystem.mm in Sources */,
 				818462311D3503E8004B0C46 /* UnloadTextureRenderCommand.cpp in Sources */,
+				81EB41181D48B3E9005A7CE9 /* CanvasDrawMode.cpp in Sources */,
 				8158F7CA1C89D2AD00B13109 /* RNGContainer.mm in Sources */,
 				818461731D3503E8004B0C46 /* TextInputStream.cpp in Sources */,
 				818461F41D3503E8004B0C46 /* SkinnedAnimation.cpp in Sources */,

--- a/Projects/iOS/ChilliSource.xcodeproj/project.pbxproj
+++ b/Projects/iOS/ChilliSource.xcodeproj/project.pbxproj
@@ -833,7 +833,6 @@
 		81845F801D3503E8004B0C46 /* CanvasRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasRenderer.cpp; sourceTree = "<group>"; };
 		81845F811D3503E8004B0C46 /* CanvasRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasRenderer.h; sourceTree = "<group>"; };
 		81845F821D3503E8004B0C46 /* CullFace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CullFace.h; sourceTree = "<group>"; };
-		81845F831D3503E8004B0C46 /* DepthTestComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DepthTestComparison.h; sourceTree = "<group>"; };
 		81845F841D3503E8004B0C46 /* ForwardRenderPassCompiler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ForwardRenderPassCompiler.cpp; sourceTree = "<group>"; };
 		81845F851D3503E8004B0C46 /* ForwardRenderPassCompiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ForwardRenderPassCompiler.h; sourceTree = "<group>"; };
 		81845F861D3503E8004B0C46 /* ForwardRenderPasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ForwardRenderPasses.h; sourceTree = "<group>"; };
@@ -1356,6 +1355,8 @@
 		81C7FFBF1C89DDE300D306F9 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		81C7FFC01C89DDE300D306F9 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		81C7FFC11C89DDE300D306F9 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		81EB410D1D460C99005A7CE9 /* StencilOp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StencilOp.h; sourceTree = "<group>"; };
+		81EB410E1D461267005A7CE9 /* TestFunc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestFunc.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2503,7 +2504,6 @@
 				81845F801D3503E8004B0C46 /* CanvasRenderer.cpp */,
 				81845F811D3503E8004B0C46 /* CanvasRenderer.h */,
 				81845F821D3503E8004B0C46 /* CullFace.h */,
-				81845F831D3503E8004B0C46 /* DepthTestComparison.h */,
 				81845F841D3503E8004B0C46 /* ForwardRenderPassCompiler.cpp */,
 				81845F851D3503E8004B0C46 /* ForwardRenderPassCompiler.h */,
 				81845F861D3503E8004B0C46 /* ForwardRenderPasses.h */,
@@ -2545,9 +2545,11 @@
 				81845FAA1D3503E8004B0C46 /* RenderSnapshot.h */,
 				81845FAB1D3503E8004B0C46 /* SizePolicy.cpp */,
 				81845FAC1D3503E8004B0C46 /* SizePolicy.h */,
+				81EB410D1D460C99005A7CE9 /* StencilOp.h */,
 				81845FAD1D3503E8004B0C46 /* SurfaceFormat.h */,
 				81845FAE1D3503E8004B0C46 /* TargetRenderPassGroup.cpp */,
 				81845FAF1D3503E8004B0C46 /* TargetRenderPassGroup.h */,
+				81EB410E1D461267005A7CE9 /* TestFunc.h */,
 				81845FB01D3503E8004B0C46 /* VerticalTextJustification.cpp */,
 				81845FB11D3503E8004B0C46 /* VerticalTextJustification.h */,
 			);

--- a/Source/CSBackend/Platform/Android/Main/Java/com/chilliworks/chillisource/core/Renderer.java
+++ b/Source/CSBackend/Platform/Android/Main/Java/com/chilliworks/chillisource/core/Renderer.java
@@ -74,7 +74,7 @@ public class Renderer implements GLSurfaceView.Renderer
 			//The surface must issue at least one draw command per draw frame call. Even if 
 			//the application isn't active
 			in_GlContext.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-			in_GlContext.glClear(GL10.GL_COLOR_BUFFER_BIT | GL10.GL_DEPTH_BUFFER_BIT);
+			in_GlContext.glClear(GL10.GL_COLOR_BUFFER_BIT | GL10.GL_DEPTH_BUFFER_BIT | GL10.GL_STENCIL_BUFFER_BIT);
 			
 			//Hacky state to allow the loading image to actually appear. Android seems to require that you draw
 			//a few frames in order for this to appear

--- a/Source/CSBackend/Platform/Android/Main/Java/com/chilliworks/chillisource/core/Surface.java
+++ b/Source/CSBackend/Platform/Android/Main/Java/com/chilliworks/chillisource/core/Surface.java
@@ -93,6 +93,22 @@ public class Surface extends GLSurfaceView
 		{
 			return new ConfigChooser(8, 8, 8, 0, 16, 32, 0);
 		}
+		else if (surfaceFormat.equalsIgnoreCase("rgb565_depth24_stencil8") == true)
+		{
+			return new ConfigChooser(5, 6, 5, 0, 16, 24, 8);
+		}
+		else if (surfaceFormat.equalsIgnoreCase("rgb565_depth32_stencil8") == true)
+		{
+			return new ConfigChooser(5, 6, 5, 0, 16, 32, 8);
+		}
+		else if (surfaceFormat.equalsIgnoreCase("rgb888_depth24_stencil8") == true)
+		{
+			return new ConfigChooser(8, 8, 8, 0, 16, 24, 8);
+		}
+		else if (surfaceFormat.equalsIgnoreCase("rgb888_depth32_stencil8") == true)
+		{
+			return new ConfigChooser(8, 8, 8, 0, 16, 32, 8);
+		}
 		else
 		{
 			Logging.logFatal("Surface: Invalid surface format.");

--- a/Source/CSBackend/Platform/iOS/Core/Base/CSGLViewController.mm
+++ b/Source/CSBackend/Platform/iOS/Core/Base/CSGLViewController.mm
@@ -161,6 +161,26 @@
             in_view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
             in_view.drawableStencilFormat = GLKViewDrawableStencilFormatNone;
             break;
+        case ChilliSource::SurfaceFormat::k_rgb565_depth24_stencil8:
+            in_view.drawableColorFormat = GLKViewDrawableColorFormatRGB565;
+            in_view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
+            in_view.drawableStencilFormat = GLKViewDrawableStencilFormat8;
+            break;
+        case ChilliSource::SurfaceFormat::k_rgb565_depth32_stencil8:
+            in_view.drawableColorFormat = GLKViewDrawableColorFormatRGB565;
+            in_view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
+            in_view.drawableStencilFormat = GLKViewDrawableStencilFormat8;
+            break;
+        case ChilliSource::SurfaceFormat::k_rgb888_depth24_stencil8:
+            in_view.drawableColorFormat = GLKViewDrawableColorFormatRGBA8888;
+            in_view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
+            in_view.drawableStencilFormat = GLKViewDrawableStencilFormat8;
+            break;
+        case ChilliSource::SurfaceFormat::k_rgb888_depth32_stencil8:
+            in_view.drawableColorFormat = GLKViewDrawableColorFormatRGBA8888;
+            in_view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
+            in_view.drawableStencilFormat = GLKViewDrawableStencilFormat8;
+            break;
     }
 }
 //-------------------------------------------------------------

--- a/Source/CSBackend/Rendering/OpenGL/Base/RenderCommandProcessor.cpp
+++ b/Source/CSBackend/Rendering/OpenGL/Base/RenderCommandProcessor.cpp
@@ -367,6 +367,8 @@ namespace CSBackend
             glClearColor(renderCommand->GetClearColour().r, renderCommand->GetClearColour().g, renderCommand->GetClearColour().b, renderCommand->GetClearColour().a);
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
             
+            glBlendEquation(GL_FUNC_ADD);
+            
             CS_ASSERT_NOGLERROR("An OpenGL error occurred while beginning rendering.");
         }
         

--- a/Source/CSBackend/Rendering/OpenGL/Base/RenderCommandProcessor.cpp
+++ b/Source/CSBackend/Rendering/OpenGL/Base/RenderCommandProcessor.cpp
@@ -365,10 +365,7 @@ namespace CSBackend
             glDepthMask(GL_TRUE);
             
             glClearColor(renderCommand->GetClearColour().r, renderCommand->GetClearColour().g, renderCommand->GetClearColour().b, renderCommand->GetClearColour().a);
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            
-            glBlendEquation(GL_FUNC_ADD);
-            glDepthFunc(GL_LEQUAL);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
             
             CS_ASSERT_NOGLERROR("An OpenGL error occurred while beginning rendering.");
         }
@@ -392,10 +389,7 @@ namespace CSBackend
             glDepthMask(GL_TRUE);
             
             glClearColor(renderCommand->GetClearColour().r, renderCommand->GetClearColour().g, renderCommand->GetClearColour().b, renderCommand->GetClearColour().a);
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            
-            glBlendEquation(GL_FUNC_ADD);
-            glDepthFunc(GL_LEQUAL);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
             
             CS_ASSERT_NOGLERROR("An OpenGL error occurred while beginning rendering with a target group.");
         }

--- a/Source/CSBackend/Rendering/OpenGL/Material/GLMaterial.cpp
+++ b/Source/CSBackend/Rendering/OpenGL/Material/GLMaterial.cpp
@@ -78,29 +78,6 @@ namespace CSBackend
                 };
             }
             
-            /// Converts from a ChilliSource blend equation to an OpenGL blend mode.
-            ///
-            /// @param blendMode
-            ///     The ChilliSource blend equation.
-            ///
-            /// @return The OpenGL blend equation.
-            ///
-            GLenum ToGLBlendEqn(ChilliSource::BlendEqn blendEqn)
-            {
-                switch(blendEqn)
-                {
-                    case ChilliSource::BlendEqn::k_add:
-                        return GL_FUNC_ADD;
-                    case ChilliSource::BlendEqn::k_subtractSrcDst:
-                        return GL_FUNC_SUBTRACT;
-                    case ChilliSource::BlendEqn::k_subtractDstSrc:
-                        return GL_FUNC_REVERSE_SUBTRACT;
-                    default:
-                        CS_LOG_FATAL("Invalid blend equation.");
-                        return GL_FUNC_ADD;
-                };
-            }
-            
             /// Converts from a ChilliSource stencil op to an OpenGL one
             ///
             /// @param stencilOp
@@ -241,7 +218,6 @@ namespace CSBackend
             if (renderMaterial->IsTransparencyEnabled())
             {
                 glEnable(GL_BLEND);
-                glBlendEquation(ToGLBlendEqn(renderMaterial->GetBlendEqn()));
                 glBlendFunc(ToGLBlendMode(renderMaterial->GetSourceBlendMode()), ToGLBlendMode(renderMaterial->GetDestinationBlendMode()));
             }
             else

--- a/Source/CSBackend/Rendering/OpenGL/Target/GLTargetGroup.cpp
+++ b/Source/CSBackend/Rendering/OpenGL/Target/GLTargetGroup.cpp
@@ -61,15 +61,17 @@ namespace CSBackend
             ///
             /// @param dimensions
             ///     The dimensions of the colour buffer.
+            /// @param format
+            ///     Format of the depth buffer
             ///
             /// @return The handle of the buffer.
             ///
-            GLuint CreateDepthRenderBuffer(const ChilliSource::Integer2& dimensions) noexcept
+            GLuint CreateDepthRenderBuffer(const ChilliSource::Integer2& dimensions, GLenum format) noexcept
             {
                 GLuint handle = 0;
                 glGenRenderbuffers(1, &handle);
                 glBindRenderbuffer(GL_RENDERBUFFER, handle);
-                glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, dimensions.x, dimensions.y);
+                glRenderbufferStorage(GL_RENDERBUFFER, format, dimensions.x, dimensions.y);
                 
                 CS_ASSERT_NOGLERROR("An OpenGL error occurred while creating a depth render buffer.");
                 
@@ -159,7 +161,7 @@ namespace CSBackend
             }
             else if (m_renderTargetGroup->ShouldUseDepthBuffer())
             {
-                m_depthRenderBufferHandle = CreateDepthRenderBuffer(m_renderTargetGroup->GetResolution());
+                m_depthRenderBufferHandle = CreateDepthRenderBuffer(m_renderTargetGroup->GetResolution(), m_renderTargetGroup->ShouldUseStencilBuffer() ? GL_DEPTH24_STENCIL8_OES : GL_DEPTH_COMPONENT16);
                 glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthRenderBufferHandle);
             }
             

--- a/Source/CSBackend/Rendering/OpenGL/Target/GLTargetGroup.cpp
+++ b/Source/CSBackend/Rendering/OpenGL/Target/GLTargetGroup.cpp
@@ -30,6 +30,10 @@
 #include <ChilliSource/Rendering/Target/RenderTargetGroup.h>
 #include <ChilliSource/Rendering/Texture/RenderTexture.h>
 
+#ifdef CS_OPENGLVERSION_ES
+	#define GL_DEPTH24_STENCIL8 GL_DEPTH24_STENCIL8_OES
+#endif
+
 namespace CSBackend
 {
     namespace OpenGL
@@ -161,7 +165,7 @@ namespace CSBackend
             }
             else if (m_renderTargetGroup->ShouldUseDepthBuffer())
             {
-                m_depthRenderBufferHandle = CreateDepthRenderBuffer(m_renderTargetGroup->GetResolution(), m_renderTargetGroup->ShouldUseStencilBuffer() ? GL_DEPTH24_STENCIL8_OES : GL_DEPTH_COMPONENT16);
+                m_depthRenderBufferHandle = CreateDepthRenderBuffer(m_renderTargetGroup->GetResolution(), m_renderTargetGroup->ShouldUseStencilBuffer() ? GL_DEPTH24_STENCIL8 : GL_DEPTH_COMPONENT16);
                 glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthRenderBufferHandle);
             }
             

--- a/Source/ChilliSource/Core/String/StringParser.cpp
+++ b/Source/ChilliSource/Core/String/StringParser.cpp
@@ -312,6 +312,22 @@ namespace ChilliSource
         {
             return SurfaceFormat::k_rgb888_depth32;
         }
+        else if (lowerCase == "rgb565_depth24_stencil8")
+        {
+            return SurfaceFormat::k_rgb565_depth24_stencil8;
+        }
+        else if (lowerCase == "rgb565_depth32_stencil8")
+        {
+            return SurfaceFormat::k_rgb565_depth32_stencil8;
+        }
+        else if (lowerCase == "rgb888_depth24_stencil8")
+        {
+            return SurfaceFormat::k_rgb888_depth24_stencil8;
+        }
+        else if (lowerCase == "rgb888_depth32_stencil8")
+        {
+            return SurfaceFormat::k_rgb888_depth32_stencil8;
+        }
         
         CS_ASSERT(false, "Invalid surface format.");
         CS_LOG_ERROR("String Parser: Invalid surface format.");

--- a/Source/ChilliSource/Rendering/Base.h
+++ b/Source/ChilliSource/Rendering/Base.h
@@ -38,7 +38,6 @@
 #include <ChilliSource/Rendering/Base/CanvasMaterialPool.h>
 #include <ChilliSource/Rendering/Base/CanvasRenderer.h>
 #include <ChilliSource/Rendering/Base/CullFace.h>
-#include <ChilliSource/Rendering/Base/DepthTestComparison.h>
 #include <ChilliSource/Rendering/Base/ForwardRenderPassCompiler.h>
 #include <ChilliSource/Rendering/Base/ForwardRenderPasses.h>
 #include <ChilliSource/Rendering/Base/FrameAllocatorQueue.h>

--- a/Source/ChilliSource/Rendering/Base.h
+++ b/Source/ChilliSource/Rendering/Base.h
@@ -59,8 +59,10 @@
 #include <ChilliSource/Rendering/Base/RenderPassVisibilityChecker.h>
 #include <ChilliSource/Rendering/Base/RenderSnapshot.h>
 #include <ChilliSource/Rendering/Base/SizePolicy.h>
+#include <ChilliSource/Rendering/Base/StencilOp.h>
 #include <ChilliSource/Rendering/Base/SurfaceFormat.h>
 #include <ChilliSource/Rendering/Base/TargetRenderPassGroup.h>
+#include <ChilliSource/Rendering/Base/TestFunc.h>
 #include <ChilliSource/Rendering/Base/VerticalTextJustification.h>
 
 #endif

--- a/Source/ChilliSource/Rendering/Base.h
+++ b/Source/ChilliSource/Rendering/Base.h
@@ -35,6 +35,7 @@
 #include <ChilliSource/Rendering/Base/AspectRatioUtils.h>
 #include <ChilliSource/Rendering/Base/BlendMode.h>
 #include <ChilliSource/Rendering/Base/CameraRenderPassGroup.h>
+#include <ChilliSource/Rendering/Base/CanvasDrawMode.h>
 #include <ChilliSource/Rendering/Base/CanvasMaterialPool.h>
 #include <ChilliSource/Rendering/Base/CanvasRenderer.h>
 #include <ChilliSource/Rendering/Base/CullFace.h>

--- a/Source/ChilliSource/Rendering/Base/BlendMode.h
+++ b/Source/ChilliSource/Rendering/Base/BlendMode.h
@@ -47,17 +47,6 @@ namespace ChilliSource
         k_destAlpha,
         k_oneMinusDestAlpha
     };
-    
-    /// Blend equation that governs how pixels are blended.
-    /// The equation specified how the new pixel colour is
-    /// combined with the colour already in the framebuffer
-    ///
-    enum class BlendEqn
-    {
-        k_add,
-        k_subtractSrcDst,
-        k_subtractDstSrc
-    };
 }
 
 #endif

--- a/Source/ChilliSource/Rendering/Base/CanvasDrawMode.cpp
+++ b/Source/ChilliSource/Rendering/Base/CanvasDrawMode.cpp
@@ -1,0 +1,45 @@
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2014 Tag Games Limited
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#include <ChilliSource/Rendering/Base/CanvasDrawMode.h>
+
+#include <ChilliSource/Core/String/StringUtils.h>
+
+namespace ChilliSource
+{
+    //------------------------------------------------------------------------------
+    CanvasDrawMode ParseCanvasDrawMode(const std::string& modeString) noexcept
+    {
+        std::string lowerCase = modeString;
+        StringUtils::ToLowerCase(lowerCase);
+        
+        if(lowerCase == "standard") return CanvasDrawMode::k_standard;
+        if(lowerCase == "mask") return CanvasDrawMode::k_mask;
+        if(lowerCase == "maskonly") return CanvasDrawMode::k_maskOnly;
+        
+        CS_LOG_FATAL("Cannot parse canvas draw mode: " + modeString);
+        return CanvasDrawMode::k_standard;
+    }
+}
+

--- a/Source/ChilliSource/Rendering/Base/CanvasDrawMode.h
+++ b/Source/ChilliSource/Rendering/Base/CanvasDrawMode.h
@@ -1,0 +1,56 @@
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2014 Tag Games Limited
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#ifndef _CHILLISOURCE_RENDERING_BASE_CANVASDRAWMODE_H_
+#define _CHILLISOURCE_RENDERING_BASE_CANVASDRAWMODE_H_
+
+#include <ChilliSource/ChilliSource.h>
+
+namespace ChilliSource
+{
+    /// Describes how the a canvas shape should be rendered
+    ///
+    /// - Standard - Renders to canvas in the standard way
+    /// - Mask - Renders to canvas and also creates a mask
+    /// - Mask Only - Doesn't render to canvas, only creates an invisible mask
+    ///
+    enum class CanvasDrawMode
+    {
+        k_standard,
+        k_mask,
+        k_maskOnly
+    };
+    
+    /// Converts a string to a draw mode (case insensitive)
+    /// Fails hard if mode unknown
+    ///
+    /// @param modeString
+    ///     Draw mode in string format
+    ///
+    /// @return CanvasDrawMode
+    ///
+    CanvasDrawMode ParseCanvasDrawMode(const std::string& modeString) noexcept;
+}
+
+#endif

--- a/Source/ChilliSource/Rendering/Base/CanvasMaterialPool.h
+++ b/Source/ChilliSource/Rendering/Base/CanvasMaterialPool.h
@@ -31,6 +31,7 @@
 
 #include <ChilliSource/ChilliSource.h>
 
+#include <functional>
 #include <tuple>
 #include <vector>
 #include <unordered_map>

--- a/Source/ChilliSource/Rendering/Base/CanvasRenderer.h
+++ b/Source/ChilliSource/Rendering/Base/CanvasRenderer.h
@@ -49,6 +49,7 @@ namespace ChilliSource
     {
     public:
         CS_DECLARE_NAMEDTYPE(CanvasRenderer);
+    
         //----------------------------------------------------------------------------
         /// A container for text properties for altering the look of built text.
         ///
@@ -119,8 +120,10 @@ namespace ChilliSource
         void DecrementClipMask() noexcept { --m_clipMaskCount; }
         
 
-        /// Renders the given sprite box to the screen
+        /// Renders the given sprite box to the screen or as a mask
         ///
+        /// @param drawMode
+        ///     Describes whether to render the box to the canvas or as a mask
         /// @param transform
         ///     2D Transformation matrix
         /// @param size
@@ -135,10 +138,8 @@ namespace ChilliSource
         ///     Colour to apply to the sprite box
         /// @param anchor
         ///     Origin anchor
-        /// @param createMask
-        ///     Whether to create a clip mask from this box shape
         ///
-        void DrawBox(const Matrix3& transform, const Vector2& size, const Vector2& offset, const TextureCSPtr& texture, const UVs& uvs, const Colour& colour, AlignmentAnchor anchor, bool createMask);
+        void DrawBox(CanvasDrawMode drawMode, const Matrix3& transform, const Vector2& size, const Vector2& offset, const TextureCSPtr& texture, const UVs& uvs, const Colour& colour, AlignmentAnchor anchor);
         
         //----------------------------------------------------------------------------
         /// Build the descriptions for all characters. The descriptions can then be
@@ -217,8 +218,9 @@ namespace ChilliSource
         
         s32 m_clipMaskCount = 0;
 
-        CanvasMaterialPoolUPtr m_colourMaterialPool;
-        CanvasMaterialPoolUPtr m_stencilMaterialPool;
+        CanvasMaterialPoolUPtr m_screenMaterialPool;
+        CanvasMaterialPoolUPtr m_screenMaskMaterialPool;
+        CanvasMaterialPoolUPtr m_maskMaterialPool;
 
         ResourcePool* m_resourcePool;
         Screen* m_screen;

--- a/Source/ChilliSource/Rendering/Base/CanvasRenderer.h
+++ b/Source/ChilliSource/Rendering/Base/CanvasRenderer.h
@@ -118,25 +118,6 @@ namespace ChilliSource
         ///
         void DecrementClipMask() noexcept { --m_clipMaskCount; }
         
-        /// Renders the given sprite box to the stencil buffer to create a clip mask
-        /// as well as rendering to the screen
-        ///
-        /// @param transform
-        ///     2D Transformation matrix
-        /// @param size
-        ///     Dimensions of the box in canvas space
-        /// @param offset
-        ///     Offset from TL of the bounds. Used to restore the cropped alpha
-        /// @param texture
-        ///     Texture (alpha channel is used to create mask shape)
-        /// @param uvs
-        ///     UVs for texture
-        /// @param anchor
-        ///     Origin anchor
-        /// @param maskValue
-        ///     Value to write into the clip mask
-        ///
-        void DrawMaskedBox(const Matrix3& transform, const Vector2& size, const Vector2& in_offset, const TextureCSPtr& in_texture, const UVs& uvs, AlignmentAnchor anchor);
 
         /// Renders the given sprite box to the screen
         ///
@@ -154,10 +135,10 @@ namespace ChilliSource
         ///     Colour to apply to the sprite box
         /// @param anchor
         ///     Origin anchor
-        /// @param maskValue
-        ///     Clip mask value used to determine if the box gets clipped or not
+        /// @param createMask
+        ///     Whether to create a clip mask from this box shape
         ///
-        void DrawBox(const Matrix3& transform, const Vector2& size, const Vector2& offset, const TextureCSPtr& texture, const UVs& uvs, const Colour& colour, AlignmentAnchor anchor);
+        void DrawBox(const Matrix3& transform, const Vector2& size, const Vector2& offset, const TextureCSPtr& texture, const UVs& uvs, const Colour& colour, AlignmentAnchor anchor, bool createMask);
         
         //----------------------------------------------------------------------------
         /// Build the descriptions for all characters. The descriptions can then be

--- a/Source/ChilliSource/Rendering/Base/StencilOp.h
+++ b/Source/ChilliSource/Rendering/Base/StencilOp.h
@@ -1,8 +1,4 @@
 //
-//  DepthTestComparison.h
-//  Chilli Source
-//  Created by Scott Downie on 09/04/2014.
-//
 //  The MIT License (MIT)
 //
 //  Copyright (c) 2014 Tag Games Limited
@@ -26,24 +22,24 @@
 //  THE SOFTWARE.
 //
 
-#ifndef _CHILLISOURCE_RENDERING_BASE_DEPTHTESTCOMPARISON_H_
-#define _CHILLISOURCE_RENDERING_BASE_DEPTHTESTCOMPARISON_H_
+#ifndef _CHILLISOURCE_RENDERING_BASE_STENCILOP_H_
+#define _CHILLISOURCE_RENDERING_BASE_STENCILOP_H_
 
 namespace ChilliSource
 {
-    //---------------------------------------------
-    /// Used in the depth test function to decide
-    /// whether a pixel should be rendered or not.
-    /// These types describe which comparison operator
-    /// should be used
+    /// The stencil ops are used to determine which action to take
+    /// on a pixel after the result of stencil testing
     ///
-    /// @author S Downie
-    //---------------------------------------------
-    enum class DepthTestComparison
+    enum class StencilOp
     {
-        k_less,
-        k_equal,
-        k_lequal
+        k_keep,             // Keeps the current value
+        k_zero,             // Sets the stencil buffer value to zero
+        k_replace,          // Sets the stencil bufer value as specified by the stencil func
+        k_increment,        // Increments the stencil buffer value, clamps to max
+        k_incrementWrap,    // Increments the stencil buffer value, wraps to zero
+        k_decrement,        // Decrements the stencil buffer value, clamps to zero
+        k_decrementWrap,    // Decrements the stencil buffer value, wraps to max
+        k_invert            // Inverts the stencil buffer value
     };
 }
 

--- a/Source/ChilliSource/Rendering/Base/SurfaceFormat.h
+++ b/Source/ChilliSource/Rendering/Base/SurfaceFormat.h
@@ -44,7 +44,11 @@ namespace ChilliSource
         k_rgb565_depth24,
         k_rgb565_depth32,
         k_rgb888_depth24,
-        k_rgb888_depth32
+        k_rgb888_depth32,
+        k_rgb565_depth24_stencil8,
+        k_rgb565_depth32_stencil8,
+        k_rgb888_depth24_stencil8,
+        k_rgb888_depth32_stencil8
     };
 }
 

--- a/Source/ChilliSource/Rendering/Base/TestFunc.h
+++ b/Source/ChilliSource/Rendering/Base/TestFunc.h
@@ -1,8 +1,4 @@
 //
-//  BlendMode.h
-//  Chilli Source
-//  Created by Scott Downie on 09/04/2014.
-//
 //  The MIT License (MIT)
 //
 //  Copyright (c) 2014 Tag Games Limited
@@ -26,37 +22,23 @@
 //  THE SOFTWARE.
 //
 
-#ifndef _CHILLISOURCE_RENDERING_BASE_BLENDMODE_H_
-#define _CHILLISOURCE_RENDERING_BASE_BLENDMODE_H_
+#ifndef _CHILLISOURCE_RENDERING_BASE_TESTFUNC_H_
+#define _CHILLISOURCE_RENDERING_BASE_TESTFUNC_H_
 
 namespace ChilliSource
 {
-    /// The blend modes that are used to describe
-    /// a blend function for rendering. The blend
-    /// function takes 2 modes - the source and
-    /// the destination.
+    /// Standard test functions that are used for depth and stencil testing
     ///
-    enum class BlendMode
+    enum class TestFunc
     {
-        k_zero,
-        k_one,
-        k_sourceCol,
-        k_oneMinusSourceCol,
-        k_sourceAlpha,
-        k_oneMinusSourceAlpha,
-        k_destAlpha,
-        k_oneMinusDestAlpha
-    };
-    
-    /// Blend equation that governs how pixels are blended.
-    /// The equation specified how the new pixel colour is
-    /// combined with the colour already in the framebuffer
-    ///
-    enum class BlendEqn
-    {
-        k_add,
-        k_subtractSrcDst,
-        k_subtractDstSrc
+        k_never,    
+        k_less,     
+        k_lessEqual,
+        k_greater,
+        k_greaterEqual,
+        k_equal,
+        k_notEqual,
+        k_always
     };
 }
 

--- a/Source/ChilliSource/Rendering/ForwardDeclarations.h
+++ b/Source/ChilliSource/Rendering/ForwardDeclarations.h
@@ -222,6 +222,7 @@ namespace ChilliSource
     CS_FORWARDDECLARE_CLASS(RenderTargetGroup);
     CS_FORWARDDECLARE_CLASS(RenderTargetGroupManager);
     CS_FORWARDDECLARE_CLASS(TargetGroup);
+    enum class RenderTargetGroupType;
     //------------------------------------------------------------
     /// Texture
     //------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/ForwardDeclarations.h
+++ b/Source/ChilliSource/Rendering/ForwardDeclarations.h
@@ -56,6 +56,7 @@ namespace ChilliSource
     CS_FORWARDDECLARE_CLASS(TargetRenderPassGroup);
     CS_FORWARDDECLARE_CLASS(CameraRenderPassGroup);
     enum class AlignmentAnchor;
+    enum class BlendEqn;
     enum class BlendMode;
     enum class CullFace;
     enum class DepthTestComparison;
@@ -63,7 +64,9 @@ namespace ChilliSource
     enum class HorizontalTextJustification;
     enum class RenderLayer;
     enum class SizePolicy;
+    enum class StencilOp;
     enum class SurfaceFormat;
+    enum class TestFunc;
     enum class VerticalTextJustification;
     //------------------------------------------------------------
     /// Camera

--- a/Source/ChilliSource/Rendering/ForwardDeclarations.h
+++ b/Source/ChilliSource/Rendering/ForwardDeclarations.h
@@ -58,6 +58,7 @@ namespace ChilliSource
     enum class AlignmentAnchor;
     enum class BlendEqn;
     enum class BlendMode;
+    enum class CanvasDrawMode;
     enum class CullFace;
     enum class DepthTestComparison;
     enum class ForwardRenderPasses;

--- a/Source/ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.cpp
+++ b/Source/ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.cpp
@@ -29,6 +29,8 @@
 #include <ChilliSource/Rendering/Base/CullFace.h>
 #include <ChilliSource/Rendering/Base/ForwardRenderPasses.h>
 #include <ChilliSource/Rendering/Base/RenderCapabilities.h>
+#include <ChilliSource/Rendering/Base/StencilOp.h>
+#include <ChilliSource/Rendering/Base/TestFunc.h>
 #include <ChilliSource/Rendering/Shader/Shader.h>
 
 namespace ChilliSource
@@ -51,10 +53,28 @@ namespace ChilliSource
         ///     Whether or not the depth test will be performed.
         /// @param isFaceCullingEnabled
         ///     Whether or not face culling will be performed.
+        /// @param isStencilTestEnabled
+        ///     Whether or not to perform stencil testing
+        /// @param depthTestFunc
+        ///     Function that determines whether a depth test comparison should pass or fail
         /// @param sourceBlendMode
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
+        /// @param blendEqn
+        ///     Describes how the source and destination colours are blended
+        /// @param stencilFailOp
+        ///     Op applied if stencil test fails
+        /// @param stencilDepthFailOp
+        ///     Op applied if stencil depth test fails
+        /// @param stencilPassOp
+        ///     Op applied if stencil and depth tests pass
+        /// @param stencilTestFunc
+        ///     Function that determines whether a stencil test comparison should pass or fail
+        /// @param stencilRef
+        ///     Value used as comparison for stencil tests
+        /// @param stencilMask
+        ///     Value ANDed to with the comparison and stencil value
         /// @param cullFace
         ///     The face which should be called. This only applies if face culling is enabled.
         /// @param ambientColour
@@ -64,8 +84,12 @@ namespace ChilliSource
         ///
         /// @return The new RenderMaterial.
         ///
-        RenderMaterialUPtr CreateUnlit(const ShaderCSPtr& shader, const RenderTexture* renderTexture, bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled,
-                                       bool isFaceCullingEnabled, BlendMode sourceBlendMode, BlendMode destinationBlendMode, CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept
+        RenderMaterialUPtr CreateUnlit(const ShaderCSPtr& shader, const RenderTexture* renderTexture,
+                                       bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                                       TestFunc depthTestFunc,
+                                       BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                       StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
+                                       CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept
         {
             auto renderShader = shader->GetRenderShader();
             std::vector<const RenderTexture*> renderTextures { renderTexture };
@@ -73,8 +97,11 @@ namespace ChilliSource
             auto specularColour = Colour::k_black;
             RenderShaderVariablesUPtr renderShaderVariables = nullptr;
             
-            return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode,
-                                                         destinationBlendMode, cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
+            return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                                         depthTestFunc,
+                                                         sourceBlendMode, destinationBlendMode, blendEqn,
+                                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
+                                                         cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
         }
         
         /// Creates a new shadow map RenderMaterial with the given shader.
@@ -93,8 +120,17 @@ namespace ChilliSource
             auto isDepthWriteEnabled = true;
             auto isDepthTestEnabled = true;
             auto isFaceCullingEnabled = true;
+            auto isStencilTestEnabled = false;
+            auto depthTestFunc = TestFunc::k_lessEqual;
             auto sourceBlendMode = BlendMode::k_one;
             auto destinationBlendMode = BlendMode::k_one;
+            auto blendEqn = BlendEqn::k_add;
+            auto stencilFailOp = StencilOp::k_keep;
+            auto stencilDepthFailOp = StencilOp::k_keep;
+            auto stencilPassOp = StencilOp::k_keep;
+            auto stencilTestFunc = TestFunc::k_always;
+            auto stencilRef = 1;
+            auto stencilMask = 0xff;
             auto cullFace = CullFace::k_front;
             auto emissiveColour = Colour::k_black;
             auto ambientColour = Colour::k_black;
@@ -102,8 +138,11 @@ namespace ChilliSource
             auto specularColour = Colour::k_black;
             RenderShaderVariablesUPtr renderShaderVariables = nullptr;
             
-            return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode,
-                                                         destinationBlendMode, cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
+            return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                                         depthTestFunc,
+                                                         sourceBlendMode, destinationBlendMode, blendEqn,
+                                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
+                                                         cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
         }
         
         /// Creates a new base pass blinn RenderMaterial with the given info.
@@ -130,15 +169,27 @@ namespace ChilliSource
             auto isDepthWriteEnabled = true;
             auto isDepthTestEnabled = true;
             auto isFaceCullingEnabled = true;
+            auto isStencilTestEnabled = false;
+            auto depthTestFunc = TestFunc::k_lessEqual;
             auto sourceBlendMode = BlendMode::k_one;
             auto destinationBlendMode = BlendMode::k_oneMinusSourceAlpha;
+            auto blendEqn = BlendEqn::k_add;
+            auto stencilFailOp = StencilOp::k_keep;
+            auto stencilDepthFailOp = StencilOp::k_keep;
+            auto stencilPassOp = StencilOp::k_keep;
+            auto stencilTestFunc = TestFunc::k_always;
+            auto stencilRef = 1;
+            auto stencilMask = 0xff;
             auto cullFace = CullFace::k_back;
             auto diffuseColour = Colour::k_black;
             auto specularColour = Colour::k_black;
             RenderShaderVariablesUPtr renderShaderVariables = nullptr;
             
-            return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode,
-                                                         destinationBlendMode, cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
+            return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                                         depthTestFunc,
+                                                         sourceBlendMode, destinationBlendMode, blendEqn,
+                                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
+                                                         cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
         }
         
         /// Creates a new light pass (directional or point) blinn RenderMaterial with the given info.
@@ -165,15 +216,27 @@ namespace ChilliSource
             auto isDepthWriteEnabled = false;
             auto isDepthTestEnabled = true;
             auto isFaceCullingEnabled = true;
+            auto isStencilTestEnabled = false;
+            auto depthTestFunc = TestFunc::k_lessEqual;
             auto sourceBlendMode = BlendMode::k_one;
             auto destinationBlendMode = BlendMode::k_one;
+            auto blendEqn = BlendEqn::k_add;
+            auto stencilFailOp = StencilOp::k_keep;
+            auto stencilDepthFailOp = StencilOp::k_keep;
+            auto stencilPassOp = StencilOp::k_keep;
+            auto stencilTestFunc = TestFunc::k_always;
+            auto stencilRef = 1;
+            auto stencilMask = 0xff;
             auto cullFace = CullFace::k_back;
             auto emissiveColour = Colour::k_black;
             auto ambientColour = Colour::k_black;
             RenderShaderVariablesUPtr renderShaderVariables = nullptr;
             
-            return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode,
-                                                         destinationBlendMode, cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
+            return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                                         depthTestFunc,
+                                                         sourceBlendMode, destinationBlendMode, blendEqn,
+                                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
+                                                         cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
         }
     }
     
@@ -186,8 +249,11 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    const RenderMaterialGroup* ForwardRenderMaterialGroupManager::CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture, bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled,
-                                                                                                 bool isDepthTestEnabled, bool isFaceCullingEnabled, BlendMode sourceBlendMode, BlendMode destinationBlendMode,
+    const RenderMaterialGroup* ForwardRenderMaterialGroupManager::CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture,
+                                                                                                 bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                                                                                                 TestFunc depthTestFunc,
+                                                                                                 BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                                                 StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                                                                                  CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept
     {
         //TODO: Create RenderMaterials from pools.
@@ -199,17 +265,26 @@ namespace ChilliSource
         
         if (isTransparencyEnabled)
         {
-            auto spriteRM = CreateUnlit(m_spriteUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode, destinationBlendMode, cullFace,
-                                        emissiveColour, ambientColour);
+            auto spriteRM = CreateUnlit(m_spriteUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                        depthTestFunc,
+                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                        stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
+                                        cullFace, emissiveColour, ambientColour);
             spriteRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_transparent)] = spriteRM.get();
             renderMaterials.push_back(std::move(spriteRM));
             
-            auto staticRM = CreateUnlit(m_staticUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode, destinationBlendMode,
+            auto staticRM = CreateUnlit(m_staticUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                        depthTestFunc,
+                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                        stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                         cullFace, emissiveColour, ambientColour);
             staticRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_transparent)] = staticRM.get();
             renderMaterials.push_back(std::move(staticRM));
             
-            auto animatedRM = CreateUnlit(m_animatedUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode, destinationBlendMode,
+            auto animatedRM = CreateUnlit(m_animatedUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                          depthTestFunc,
+                                          sourceBlendMode, destinationBlendMode, blendEqn,
+                                          stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                         cullFace, emissiveColour, ambientColour);
             animatedRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_transparent)] = animatedRM.get();
             renderMaterials.push_back(std::move(animatedRM));
@@ -217,17 +292,26 @@ namespace ChilliSource
         else
         {
             //TODO: Create RenderMaterials from pools.
-            auto spriteRM = CreateUnlit(m_spriteUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode, destinationBlendMode, cullFace,
-                                        emissiveColour, ambientColour);
+            auto spriteRM = CreateUnlit(m_spriteUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                        depthTestFunc,
+                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                        stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
+                                        cullFace, emissiveColour, ambientColour);
             spriteRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_base)] = spriteRM.get();
             renderMaterials.push_back(std::move(spriteRM));
             
-            auto staticRM = CreateUnlit(m_staticUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode, destinationBlendMode,
+            auto staticRM = CreateUnlit(m_staticUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                        depthTestFunc,
+                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                        stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                         cullFace, emissiveColour, ambientColour);
             staticRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_base)] = staticRM.get();
             renderMaterials.push_back(std::move(staticRM));
             
-            auto animatedRM = CreateUnlit(m_animatedUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode, destinationBlendMode,
+            auto animatedRM = CreateUnlit(m_animatedUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                          depthTestFunc,
+                                          sourceBlendMode, destinationBlendMode, blendEqn,
+                                          stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                           cullFace, emissiveColour, ambientColour);
             animatedRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_base)] = animatedRM.get();
             renderMaterials.push_back(std::move(animatedRM));
@@ -326,9 +410,11 @@ namespace ChilliSource
     
     //------------------------------------------------------------------------------
     const RenderMaterialGroup* ForwardRenderMaterialGroupManager::CreateCustomRenderMaterialGroup(const VertexFormat& vertexFormat, const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
-                                                                                                  bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled,
-                                                                                                  bool isFaceCullingEnabled, BlendMode sourceBlendMode, BlendMode destinationBlendMode, CullFace cullFace,
-                                                                                                  const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
+                                                                                                  bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                                                                                                  TestFunc depthTestFunc,
+                                                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                                                  StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
+                                                                                                  CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
                                                                                                   RenderShaderVariablesUPtr renderShaderVariables) noexcept
     {
         //TODO: Create RenderMaterials from pools.
@@ -338,15 +424,23 @@ namespace ChilliSource
         
         if (isTransparencyEnabled)
         {
-            auto renderMaterial = RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode,
-                                                                        destinationBlendMode, cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
+            auto renderMaterial = RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures,
+                                                                        isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                                                        depthTestFunc,
+                                                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                                                        stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
+                                                                        cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
             renderMaterialsSlots[static_cast<u32>(ForwardRenderPasses::k_transparent)] = renderMaterial.get();
             renderMaterials.push_back(std::move(renderMaterial));
         }
         else
         {
-            auto renderMaterial = RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, sourceBlendMode,
-                                                                        destinationBlendMode, cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
+            auto renderMaterial = RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures,
+                                                                        isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
+                                                                        depthTestFunc,
+                                                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                                                        stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
+                                                                        cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
             renderMaterialsSlots[static_cast<u32>(ForwardRenderPasses::k_base)] = renderMaterial.get();
             renderMaterials.push_back(std::move(renderMaterial));
             

--- a/Source/ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.cpp
+++ b/Source/ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.cpp
@@ -61,8 +61,6 @@ namespace ChilliSource
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
-        /// @param blendEqn
-        ///     Describes how the source and destination colours are blended
         /// @param stencilFailOp
         ///     Op applied if stencil test fails
         /// @param stencilDepthFailOp
@@ -87,7 +85,7 @@ namespace ChilliSource
         RenderMaterialUPtr CreateUnlit(const ShaderCSPtr& shader, const RenderTexture* renderTexture,
                                        bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                                        TestFunc depthTestFunc,
-                                       BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                       BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                                        StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                        CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept
         {
@@ -99,7 +97,7 @@ namespace ChilliSource
             
             return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                                          depthTestFunc,
-                                                         sourceBlendMode, destinationBlendMode, blendEqn,
+                                                         sourceBlendMode, destinationBlendMode,
                                                          stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                                          cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
         }
@@ -124,7 +122,6 @@ namespace ChilliSource
             auto depthTestFunc = TestFunc::k_lessEqual;
             auto sourceBlendMode = BlendMode::k_one;
             auto destinationBlendMode = BlendMode::k_one;
-            auto blendEqn = BlendEqn::k_add;
             auto stencilFailOp = StencilOp::k_keep;
             auto stencilDepthFailOp = StencilOp::k_keep;
             auto stencilPassOp = StencilOp::k_keep;
@@ -140,7 +137,7 @@ namespace ChilliSource
             
             return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                                          depthTestFunc,
-                                                         sourceBlendMode, destinationBlendMode, blendEqn,
+                                                         sourceBlendMode, destinationBlendMode,
                                                          stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                                          cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
         }
@@ -173,7 +170,6 @@ namespace ChilliSource
             auto depthTestFunc = TestFunc::k_lessEqual;
             auto sourceBlendMode = BlendMode::k_one;
             auto destinationBlendMode = BlendMode::k_oneMinusSourceAlpha;
-            auto blendEqn = BlendEqn::k_add;
             auto stencilFailOp = StencilOp::k_keep;
             auto stencilDepthFailOp = StencilOp::k_keep;
             auto stencilPassOp = StencilOp::k_keep;
@@ -187,7 +183,7 @@ namespace ChilliSource
             
             return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                                          depthTestFunc,
-                                                         sourceBlendMode, destinationBlendMode, blendEqn,
+                                                         sourceBlendMode, destinationBlendMode,
                                                          stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                                          cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
         }
@@ -220,7 +216,6 @@ namespace ChilliSource
             auto depthTestFunc = TestFunc::k_lessEqual;
             auto sourceBlendMode = BlendMode::k_one;
             auto destinationBlendMode = BlendMode::k_one;
-            auto blendEqn = BlendEqn::k_add;
             auto stencilFailOp = StencilOp::k_keep;
             auto stencilDepthFailOp = StencilOp::k_keep;
             auto stencilPassOp = StencilOp::k_keep;
@@ -234,7 +229,7 @@ namespace ChilliSource
             
             return RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                                          depthTestFunc,
-                                                         sourceBlendMode, destinationBlendMode, blendEqn,
+                                                         sourceBlendMode, destinationBlendMode,
                                                          stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                                          cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
         }
@@ -252,7 +247,7 @@ namespace ChilliSource
     const RenderMaterialGroup* ForwardRenderMaterialGroupManager::CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture,
                                                                                                  bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                                                                                                  TestFunc depthTestFunc,
-                                                                                                 BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                                                 BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                                                                                                  StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                                                                                  CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept
     {
@@ -267,7 +262,7 @@ namespace ChilliSource
         {
             auto spriteRM = CreateUnlit(m_spriteUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                         depthTestFunc,
-                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                        sourceBlendMode, destinationBlendMode,
                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                         cullFace, emissiveColour, ambientColour);
             spriteRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_transparent)] = spriteRM.get();
@@ -275,7 +270,7 @@ namespace ChilliSource
             
             auto staticRM = CreateUnlit(m_staticUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                         depthTestFunc,
-                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                        sourceBlendMode, destinationBlendMode,
                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                         cullFace, emissiveColour, ambientColour);
             staticRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_transparent)] = staticRM.get();
@@ -283,7 +278,7 @@ namespace ChilliSource
             
             auto animatedRM = CreateUnlit(m_animatedUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                           depthTestFunc,
-                                          sourceBlendMode, destinationBlendMode, blendEqn,
+                                          sourceBlendMode, destinationBlendMode,
                                           stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                         cullFace, emissiveColour, ambientColour);
             animatedRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_transparent)] = animatedRM.get();
@@ -294,7 +289,7 @@ namespace ChilliSource
             //TODO: Create RenderMaterials from pools.
             auto spriteRM = CreateUnlit(m_spriteUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                         depthTestFunc,
-                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                        sourceBlendMode, destinationBlendMode,
                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                         cullFace, emissiveColour, ambientColour);
             spriteRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_base)] = spriteRM.get();
@@ -302,7 +297,7 @@ namespace ChilliSource
             
             auto staticRM = CreateUnlit(m_staticUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                         depthTestFunc,
-                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                        sourceBlendMode, destinationBlendMode,
                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                         cullFace, emissiveColour, ambientColour);
             staticRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_base)] = staticRM.get();
@@ -310,7 +305,7 @@ namespace ChilliSource
             
             auto animatedRM = CreateUnlit(m_animatedUnlit, renderTexture, isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                           depthTestFunc,
-                                          sourceBlendMode, destinationBlendMode, blendEqn,
+                                          sourceBlendMode, destinationBlendMode,
                                           stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                           cullFace, emissiveColour, ambientColour);
             animatedRenderMaterials[static_cast<u32>(ForwardRenderPasses::k_base)] = animatedRM.get();
@@ -412,7 +407,7 @@ namespace ChilliSource
     const RenderMaterialGroup* ForwardRenderMaterialGroupManager::CreateCustomRenderMaterialGroup(const VertexFormat& vertexFormat, const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
                                                                                                   bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                                                                                                   TestFunc depthTestFunc,
-                                                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                                                                                                   StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                                                                                   CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
                                                                                                   RenderShaderVariablesUPtr renderShaderVariables) noexcept
@@ -427,7 +422,7 @@ namespace ChilliSource
             auto renderMaterial = RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures,
                                                                         isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                                                         depthTestFunc,
-                                                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                                                        sourceBlendMode, destinationBlendMode,
                                                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                                                         cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
             renderMaterialsSlots[static_cast<u32>(ForwardRenderPasses::k_transparent)] = renderMaterial.get();
@@ -438,7 +433,7 @@ namespace ChilliSource
             auto renderMaterial = RenderMaterialUPtr(new RenderMaterial(renderShader, renderTextures,
                                                                         isTransparencyEnabled, isColourWriteEnabled, isDepthWriteEnabled, isDepthTestEnabled, isFaceCullingEnabled, isStencilTestEnabled,
                                                                         depthTestFunc,
-                                                                        sourceBlendMode, destinationBlendMode, blendEqn,
+                                                                        sourceBlendMode, destinationBlendMode,
                                                                         stencilFailOp, stencilDepthFailOp, stencilPassOp, stencilTestFunc, stencilRef, stencilMask,
                                                                         cullFace, emissiveColour, ambientColour, diffuseColour, specularColour, std::move(renderShaderVariables)));
             renderMaterialsSlots[static_cast<u32>(ForwardRenderPasses::k_base)] = renderMaterial.get();

--- a/Source/ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.h
+++ b/Source/ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.h
@@ -67,10 +67,28 @@ namespace ChilliSource
         ///     Whether or not the depth test will be performed.
         /// @param isFaceCullingEnabled
         ///     Whether or not face culling will be performed.
+        /// @param isStencilTestEnabled
+        ///     Whether or not to perform stencil testing
+        /// @param depthTestFunc
+        ///     Function that determines whether a depth test comparison should pass or fail
         /// @param sourceBlendMode
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
+        /// @param blendEqn
+        ///     Describes how the source and destination colours are blended
+        /// @param stencilFailOp
+        ///     Op applied if stencil test fails
+        /// @param stencilDepthFailOp
+        ///     Op applied if stencil depth test fails
+        /// @param stencilPassOp
+        ///     Op applied if stencil and depth tests pass
+        /// @param stencilTestFunc
+        ///     Function that determines whether a stencil test comparison should pass or fail
+        /// @param stencilRef
+        ///     Value used as comparison for stencil tests
+        /// @param stencilMask
+        ///     Value ANDed to with the comparison and stencil value
         /// @param cullFace
         ///     The face which should be called. This only applies if face culling is enabled.
         /// @param ambientColour
@@ -80,9 +98,12 @@ namespace ChilliSource
         ///
         /// @return The new material group.
         ///
-        const RenderMaterialGroup* CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture, bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled,
-                                                                  bool isDepthTestEnabled, bool isFaceCullingEnabled, BlendMode sourceBlendMode, BlendMode destinationBlendMode, CullFace cullFace,
-                                                                  const Colour& emissiveColour, const Colour& ambientColour) noexcept override;
+        const RenderMaterialGroup* CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture,
+                                                                  bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                                                                  TestFunc depthTestFunc,
+                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                  StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
+                                                                  CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept override;
         
         /// Creates a new blinn RenderMaterialGroup and queues a LoadMaterialGroupRenderCommand for the next
         /// Render Snapshot stage in the render pipeline.
@@ -122,15 +143,33 @@ namespace ChilliSource
         ///     Whether or not the depth test will be performed.
         /// @param isFaceCullingEnabled
         ///     Whether or not face culling will be performed.
+        /// @param isStencilTestEnabled
+        ///     Whether or not to perform stencil testing
+        /// @param depthTestFunc
+        ///     Function that determines whether a depth test comparison should pass or fail
         /// @param sourceBlendMode
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
+        /// @param blendEqn
+        ///     Describes how the source and destination colours are blended
+        /// @param stencilFailOp
+        ///     Op applied if stencil test fails
+        /// @param stencilDepthFailOp
+        ///     Op applied if stencil depth test fails
+        /// @param stencilPassOp
+        ///     Op applied if stencil and depth tests pass
+        /// @param stencilTestFunc
+        ///     Function that determines whether a stencil test comparison should pass or fail
+        /// @param stencilRef
+        ///     Value used as comparison for stencil tests
+        /// @param stencilMask
+        ///     Value ANDed to with the comparison and stencil value
         /// @param cullFace
         ///     The face which should be called. This only applies if face culling is enabled.
-        /// @param ambientColour
-        ///     The ambient colour.
         /// @param emissiveColour
+        ///     The ambient colour.
+        /// @param ambientColour
         ///     The ambient colour.
         /// @param diffuseColour
         ///     The diffuse colour.
@@ -141,9 +180,13 @@ namespace ChilliSource
         ///
         /// @return The new material group.
         ///
-        const RenderMaterialGroup* CreateCustomRenderMaterialGroup(const VertexFormat& vertexFormat, const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures, bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled,
-                                                                   bool isDepthTestEnabled, bool isFaceCullingEnabled, BlendMode sourceBlendMode, BlendMode destinationBlendMode, CullFace cullFace, const Colour& emissiveColour,
-                                                                   const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour, RenderShaderVariablesUPtr renderShaderVariables) noexcept override;
+        const RenderMaterialGroup* CreateCustomRenderMaterialGroup(const VertexFormat& vertexFormat, const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
+                                                                   bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                                                                   TestFunc depthTestFunc,
+                                                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                   StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
+                                                                   CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
+                                                                   RenderShaderVariablesUPtr renderShaderVariables) noexcept override;
         
     private:
         friend class RenderMaterialGroupManager;

--- a/Source/ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.h
+++ b/Source/ChilliSource/Rendering/Material/ForwardRenderMaterialGroupManager.h
@@ -75,8 +75,6 @@ namespace ChilliSource
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
-        /// @param blendEqn
-        ///     Describes how the source and destination colours are blended
         /// @param stencilFailOp
         ///     Op applied if stencil test fails
         /// @param stencilDepthFailOp
@@ -101,7 +99,7 @@ namespace ChilliSource
         const RenderMaterialGroup* CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture,
                                                                   bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                                                                   TestFunc depthTestFunc,
-                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                                                                   StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                                                   CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept override;
         
@@ -151,8 +149,6 @@ namespace ChilliSource
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
-        /// @param blendEqn
-        ///     Describes how the source and destination colours are blended
         /// @param stencilFailOp
         ///     Op applied if stencil test fails
         /// @param stencilDepthFailOp
@@ -183,7 +179,7 @@ namespace ChilliSource
         const RenderMaterialGroup* CreateCustomRenderMaterialGroup(const VertexFormat& vertexFormat, const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
                                                                    bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                                                                    TestFunc depthTestFunc,
-                                                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                                                                    StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                                                    CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
                                                                    RenderShaderVariablesUPtr renderShaderVariables) noexcept override;

--- a/Source/ChilliSource/Rendering/Material/Material.cpp
+++ b/Source/ChilliSource/Rendering/Material/Material.cpp
@@ -52,7 +52,7 @@ namespace ChilliSource
     //------------------------------------------------
     //------------------------------------------------
     Material::Material() noexcept
-    :   m_srcBlendMode(BlendMode::k_one), m_dstBlendMode(BlendMode::k_oneMinusSourceAlpha), m_blendEqn(BlendEqn::k_add),
+    :   m_srcBlendMode(BlendMode::k_one), m_dstBlendMode(BlendMode::k_oneMinusSourceAlpha),
         m_depthTestFunc(TestFunc::k_lessEqual),
         m_cullFace(CullFace::k_back),
         m_stencilPassOp(StencilOp::k_keep), m_stencilFailOp(StencilOp::k_keep), m_stencilDepthFailOp(StencilOp::k_keep)
@@ -412,7 +412,7 @@ namespace ChilliSource
         m_renderMaterialGroup = m_renderMaterialGroupManager->CreateUnlitRenderMaterialGroup(renderTexture,
                                                                                              m_isAlphaBlendingEnabled, m_isColWriteEnabled, m_isDepthWriteEnabled, m_isDepthTestEnabled, m_isFaceCullingEnabled, m_isStencilTestEnabled,
                                                                                              m_depthTestFunc,
-                                                                                             m_srcBlendMode, m_dstBlendMode, m_blendEqn,
+                                                                                             m_srcBlendMode, m_dstBlendMode,
                                                                                              m_stencilFailOp, m_stencilDepthFailOp, m_stencilPassOp, m_stencilTestFunc, m_stencilTestFuncRef, m_stencilTestFuncMask,
                                                                                              m_cullFace, m_emissive, m_ambient);
     }
@@ -460,7 +460,7 @@ namespace ChilliSource
         m_renderMaterialGroup = m_renderMaterialGroupManager->CreateCustomRenderMaterialGroup(m_customShaderVertexFormat, renderShader, renderTextures,
                                                                                               m_isAlphaBlendingEnabled, m_isColWriteEnabled, m_isDepthWriteEnabled, m_isDepthTestEnabled, m_isFaceCullingEnabled, m_isStencilTestEnabled,
                                                                                               m_depthTestFunc,
-                                                                                              m_srcBlendMode, m_dstBlendMode, m_blendEqn,
+                                                                                              m_srcBlendMode, m_dstBlendMode,
                                                                                               m_stencilFailOp, m_stencilDepthFailOp, m_stencilPassOp, m_stencilTestFunc, m_stencilTestFuncRef, m_stencilTestFuncMask,
                                                                                               m_cullFace, m_emissive, m_ambient, m_diffuse, m_specular, std::move(renderShaderVariables));
     }

--- a/Source/ChilliSource/Rendering/Material/Material.cpp
+++ b/Source/ChilliSource/Rendering/Material/Material.cpp
@@ -213,11 +213,16 @@ namespace ChilliSource
     }
     //----------------------------------------------------------
     //----------------------------------------------------------
-    void Material::SetStencilTests(StencilOp stencilFail, StencilOp depthFail, StencilOp pass, TestFunc testFunc, s32 ref, u32 mask) noexcept
+    void Material::SetStencilPostTestOps(StencilOp stencilFail, StencilOp depthFail, StencilOp pass) noexcept
     {
         m_stencilFailOp = stencilFail;
         m_stencilDepthFailOp = depthFail;
         m_stencilPassOp = pass;
+    }
+    //----------------------------------------------------------
+    //----------------------------------------------------------
+    void Material::SetStencilTestFunc(TestFunc testFunc, s32 ref, u32 mask) noexcept
+    {
         m_stencilTestFunc = testFunc;
         m_stencilTestFuncRef = ref;
         m_stencilTestFuncMask = mask;

--- a/Source/ChilliSource/Rendering/Material/Material.h
+++ b/Source/ChilliSource/Rendering/Material/Material.h
@@ -238,14 +238,6 @@ namespace ChilliSource
         /// @return Dest BlendMode of blending functions
         //----------------------------------------------------------
         BlendMode GetDestBlendMode() const;
-
-        /// @param The equation that describes how source and dest pixels are blended
-        ///
-        void SetBlendEqn(BlendEqn eqn) noexcept { m_blendEqn = eqn; }
-        
-        /// @return The equation that describes how source and dest pixels are blended
-        ///
-        BlendEqn GetBlendEqn() const noexcept { return m_blendEqn; }
         
         /// Tells the render system what action to take with the result of a stencil test
         ///
@@ -525,7 +517,6 @@ namespace ChilliSource
         
         BlendMode m_srcBlendMode;
         BlendMode m_dstBlendMode;
-        BlendEqn m_blendEqn;
         
         CullFace m_cullFace;
         

--- a/Source/ChilliSource/Rendering/Material/Material.h
+++ b/Source/ChilliSource/Rendering/Material/Material.h
@@ -198,6 +198,24 @@ namespace ChilliSource
         /// @param Whether face culling is enabled
         //----------------------------------------------------------
         void SetFaceCullingEnabled(bool in_enable);
+    
+        /// @return Whether or not to perform stencil testing
+        ///
+        bool IsStencilTestEnabled() const noexcept { return m_isStencilTestEnabled; }
+
+        /// @param in_enable
+        ///     Whether to turn stencil testing on or off
+        ///
+        void SetStencilTestEnabled(bool in_enable) noexcept { m_isStencilTestEnabled = in_enable; }
+        
+        /// @param Function that handles comparing depth values for pass/fail testing
+        ///
+        void SetDepthTestFunc(TestFunc testFunc) noexcept { m_depthTestFunc = testFunc; }
+        
+        /// @return Function that handles comparing depth values for pass/fail testing
+        ///
+        TestFunc GetDepthTestFunc() const noexcept { return m_depthTestFunc; }
+        
         //----------------------------------------------------------
         /// Tells the render system how to blend pixels based on the
         /// source and destination mode
@@ -220,6 +238,56 @@ namespace ChilliSource
         /// @return Dest BlendMode of blending functions
         //----------------------------------------------------------
         BlendMode GetDestBlendMode() const;
+
+        /// @param The equation that describes how source and dest pixels are blended
+        ///
+        void SetBlendEqn(BlendEqn eqn) noexcept { m_blendEqn = eqn; }
+        
+        /// @return The equation that describes how source and dest pixels are blended
+        ///
+        BlendEqn GetBlendEqn() const noexcept { return m_blendEqn; }
+        
+        /// Tells the render system what action to take when performing
+        /// a stencil test
+        ///
+        /// @param stencilFail
+        ///     Action to take if the stencil test fails
+        /// @param depthFail
+        ///     Action to take if the stencil test passes but depth test fails
+        /// @param pass
+        ///     Action to take when stencil and depth tests pass
+        /// @param testFunc
+        ///     Function that uses the value in the stencil and the ref to decide whether a comparison passes or fails
+        /// @param ref
+        ///     Comparison value for the test func
+        /// @param mask
+        ///     ANDed with the ref and the sampled value prior to the comparison test
+        void SetStencilTests(StencilOp stencilFail, StencilOp depthFail, StencilOp pass, TestFunc testFunc, s32 ref, u32 mask) noexcept;
+        
+        /// @return Op to use if stencil test fails
+        ///
+        StencilOp GetStencilFailOp() const noexcept { return m_stencilFailOp; }
+        
+        /// @return Op to use if stencil test passes but depth test fails
+        ///
+        StencilOp GetStencilDepthFailOp() const noexcept { return m_stencilDepthFailOp; }
+        
+        /// @return Op to use if stencil and depth tests pass
+        ///
+        StencilOp GetStencilPassOp() const noexcept { return m_stencilPassOp; }
+        
+        /// @return Function that handles comparing stencil values for pass/fail testing
+        ///
+        TestFunc GetStencilTestFunc() const noexcept { return m_stencilTestFunc; }
+        
+        /// @return The comparison value for the stencil test function
+        ///
+        s32 GetStencilTestFuncRef() const noexcept { return m_stencilTestFuncRef; }
+        
+        /// @return The mask that is ANDed with the ref and stored value
+        ///
+        u32 GetStencilTestFuncMask() const noexcept { return m_stencilTestFuncMask; }
+        
         //----------------------------------------------------------
         /// @author S Downie
         ///
@@ -448,16 +516,27 @@ namespace ChilliSource
         Colour m_diffuse;
         Colour m_specular;
         
+        TestFunc m_depthTestFunc;
+        
         BlendMode m_srcBlendMode;
         BlendMode m_dstBlendMode;
+        BlendEqn m_blendEqn;
+        
         CullFace m_cullFace;
         
+        StencilOp m_stencilFailOp;
+        StencilOp m_stencilDepthFailOp;
+        StencilOp m_stencilPassOp;
+        s32 m_stencilTestFuncRef = 1;
+        u32 m_stencilTestFuncMask = 0xff;
+        TestFunc m_stencilTestFunc;
 
         bool m_isAlphaBlendingEnabled = false;
         bool m_isColWriteEnabled = true;
         bool m_isDepthWriteEnabled = true;
         bool m_isDepthTestEnabled = true;
         bool m_isFaceCullingEnabled = true;
+        bool m_isStencilTestEnabled = false;
         
         ShaderCSPtr m_customShader;
         VertexFormat m_customShaderVertexFormat = VertexFormat::k_sprite;

--- a/Source/ChilliSource/Rendering/Material/Material.h
+++ b/Source/ChilliSource/Rendering/Material/Material.h
@@ -247,8 +247,7 @@ namespace ChilliSource
         ///
         BlendEqn GetBlendEqn() const noexcept { return m_blendEqn; }
         
-        /// Tells the render system what action to take when performing
-        /// a stencil test
+        /// Tells the render system what action to take with the result of a stencil test
         ///
         /// @param stencilFail
         ///     Action to take if the stencil test fails
@@ -256,13 +255,19 @@ namespace ChilliSource
         ///     Action to take if the stencil test passes but depth test fails
         /// @param pass
         ///     Action to take when stencil and depth tests pass
+        ///
+        void SetStencilPostTestOps(StencilOp stencilFail, StencilOp depthFail, StencilOp pass) noexcept;
+        
+        /// Tells the render system what comparison function to apply when performing a stencil test
+        ///
         /// @param testFunc
         ///     Function that uses the value in the stencil and the ref to decide whether a comparison passes or fails
         /// @param ref
         ///     Comparison value for the test func
         /// @param mask
         ///     ANDed with the ref and the sampled value prior to the comparison test
-        void SetStencilTests(StencilOp stencilFail, StencilOp depthFail, StencilOp pass, TestFunc testFunc, s32 ref, u32 mask) noexcept;
+        ///
+        void SetStencilTestFunc(TestFunc testFunc, s32 ref, u32 mask) noexcept;
         
         /// @return Op to use if stencil test fails
         ///

--- a/Source/ChilliSource/Rendering/Material/RenderMaterial.cpp
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterial.cpp
@@ -27,12 +27,20 @@
 namespace ChilliSource
 {
     //------------------------------------------------------------------------------
-    RenderMaterial::RenderMaterial(const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures, bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled,
-                                   bool isDepthTestEnabled, bool isFaceCullingEnabled, BlendMode sourceBlendMode, BlendMode destinationBlendMode, CullFace cullFace, const Colour& emissiveColour,
-                                   const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour, RenderShaderVariablesUPtr renderShaderVariables) noexcept
-        : m_renderShader(renderShader), m_renderTextures(renderTextures), m_isTransparencyEnabled(isTransparencyEnabled), m_isColourWriteEnabled(isColourWriteEnabled), m_isDepthWriteEnabled(isDepthWriteEnabled),
-          m_isDepthTestEnabled(isDepthTestEnabled), m_isFaceCullingEnabled(isFaceCullingEnabled), m_sourceBlendMode(sourceBlendMode), m_destinationBlendMode(destinationBlendMode), m_cullFace(cullFace),
-          m_emissiveColour(emissiveColour), m_ambientColour(ambientColour), m_diffuseColour(diffuseColour), m_specularColour(specularColour), m_renderShaderVariables(std::move(renderShaderVariables))
+    RenderMaterial::RenderMaterial(const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
+                                   bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                                   TestFunc depthTestFunc,
+                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                   StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
+                                   CullFace cullFace,
+                                   const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
+                                   RenderShaderVariablesUPtr renderShaderVariables) noexcept
+        :   m_renderShader(renderShader), m_renderTextures(renderTextures),
+            m_isTransparencyEnabled(isTransparencyEnabled), m_isColourWriteEnabled(isColourWriteEnabled), m_isDepthWriteEnabled(isDepthWriteEnabled), m_isDepthTestEnabled(isDepthTestEnabled), m_isFaceCullingEnabled(isFaceCullingEnabled), m_isStencilTestEnabled(isStencilTestEnabled),
+            m_depthTestFunc(depthTestFunc),
+            m_sourceBlendMode(sourceBlendMode), m_destinationBlendMode(destinationBlendMode), m_blendEqn(blendEqn),
+            m_stencilFailOp(stencilFailOp), m_stencilDepthFailOp(stencilDepthFailOp), m_stencilPassOp(stencilPassOp), m_stencilTestFunc(stencilTestFunc), m_stencilTestFuncRef(stencilRef), m_stencilTestFuncMask(stencilMask),
+            m_cullFace(cullFace), m_emissiveColour(emissiveColour), m_ambientColour(ambientColour), m_diffuseColour(diffuseColour), m_specularColour(specularColour), m_renderShaderVariables(std::move(renderShaderVariables))
     {
     }
 }

--- a/Source/ChilliSource/Rendering/Material/RenderMaterial.cpp
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterial.cpp
@@ -30,7 +30,7 @@ namespace ChilliSource
     RenderMaterial::RenderMaterial(const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
                                    bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                                    TestFunc depthTestFunc,
-                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                                    StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                    CullFace cullFace,
                                    const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
@@ -38,7 +38,7 @@ namespace ChilliSource
         :   m_renderShader(renderShader), m_renderTextures(renderTextures),
             m_isTransparencyEnabled(isTransparencyEnabled), m_isColourWriteEnabled(isColourWriteEnabled), m_isDepthWriteEnabled(isDepthWriteEnabled), m_isDepthTestEnabled(isDepthTestEnabled), m_isFaceCullingEnabled(isFaceCullingEnabled), m_isStencilTestEnabled(isStencilTestEnabled),
             m_depthTestFunc(depthTestFunc),
-            m_sourceBlendMode(sourceBlendMode), m_destinationBlendMode(destinationBlendMode), m_blendEqn(blendEqn),
+            m_sourceBlendMode(sourceBlendMode), m_destinationBlendMode(destinationBlendMode),
             m_stencilFailOp(stencilFailOp), m_stencilDepthFailOp(stencilDepthFailOp), m_stencilPassOp(stencilPassOp), m_stencilTestFunc(stencilTestFunc), m_stencilTestFuncRef(stencilRef), m_stencilTestFuncMask(stencilMask),
             m_cullFace(cullFace), m_emissiveColour(emissiveColour), m_ambientColour(ambientColour), m_diffuseColour(diffuseColour), m_specularColour(specularColour), m_renderShaderVariables(std::move(renderShaderVariables))
     {

--- a/Source/ChilliSource/Rendering/Material/RenderMaterial.h
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterial.h
@@ -59,10 +59,28 @@ namespace ChilliSource
         ///     Whether or not the depth test will be performed.
         /// @param isFaceCullingEnabled
         ///     Whether or not face culling will be performed.
+        /// @param isStencilTestEnabled
+        ///     Whether or not to perform stencil testing
+        /// @param depthTestFunc
+        ///     Function that determines whether a depth test comparison should pass or fail
         /// @param sourceBlendMode
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
+        /// @param blendEqn
+        ///     Describes how the source and destination colours are blended
+        /// @param stencilFailOp
+        ///     Op applied if stencil test fails
+        /// @param stencilDepthFailOp
+        ///     Op applied if stencil depth test fails
+        /// @param stencilPassOp
+        ///     Op applied if stencil and depth tests pass
+        /// @param stencilTestFunc
+        ///     Function that determines whether a stencil test comparison should pass or fail
+        /// @param stencilRef
+        ///     Value used as comparison for stencil tests
+        /// @param stencilMask
+        ///     Value ANDed to with the comparison and stencil value
         /// @param cullFace
         ///     The face which should be called. This only applies if face culling is enabled.
         /// @param emissiveColour
@@ -76,9 +94,14 @@ namespace ChilliSource
         /// @param renderShaderVariables
         ///     The container for all render shader variables. May be null if there are no shader variables.
         ///
-        RenderMaterial(const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures, bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled,
-                       bool isDepthTestEnabled, bool isFaceCullingEnabled, BlendMode sourceBlendMode, BlendMode destinationBlendMode, CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour,
-                       const Colour& diffuseColour, const Colour& specularColour, RenderShaderVariablesUPtr renderShaderVariables) noexcept;
+        RenderMaterial(const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
+                       bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                       TestFunc depthTestFunc,
+                       BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                       StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
+                       CullFace cullFace,
+                       const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
+                       RenderShaderVariablesUPtr renderShaderVariables) noexcept;
         
         /// @return The shader applied by this material.
         ///
@@ -108,6 +131,14 @@ namespace ChilliSource
         ///
         bool IsFaceCullingEnabled() const noexcept { return m_isFaceCullingEnabled; }
         
+        /// @return Whether or not to perform stencil testing
+        ///
+        bool IsStencilTestEnabled() const noexcept { return m_isStencilTestEnabled; }
+        
+        /// @return Function that handles comparing depth values for pass/fail testing
+        ///
+        TestFunc GetDepthTestFunc() const noexcept { return m_depthTestFunc; }
+        
         /// @return The source blend mode. This only applies if transparency is enabled.
         ///
         BlendMode GetSourceBlendMode() const noexcept { return m_sourceBlendMode; }
@@ -116,9 +147,37 @@ namespace ChilliSource
         ///
         BlendMode GetDestinationBlendMode() const noexcept { return m_destinationBlendMode; }
         
+        /// @return The equation that describes how source and dest pixels are blended
+        ///
+        BlendEqn GetBlendEqn() const noexcept { return m_blendEqn; }
+        
         /// @return The face which should be called. This only applies if face culling is enabled.
         ///
         CullFace GetCullFace() const noexcept { return m_cullFace; }
+        
+        /// @return Op to use if stencil test fails
+        ///
+        StencilOp GetStencilFailOp() const noexcept { return m_stencilFailOp; }
+        
+        /// @return Op to use if stencil test passes but depth test fails
+        ///
+        StencilOp GetStencilDepthFailOp() const noexcept { return m_stencilDepthFailOp; }
+        
+        /// @return Op to use if stencil and depth tests pass
+        ///
+        StencilOp GetStencilPassOp() const noexcept { return m_stencilPassOp; }
+        
+        /// @return Function that handles comparing stencil values for pass/fail testing
+        ///
+        TestFunc GetStencilTestFunc() const noexcept { return m_stencilTestFunc; }
+        
+        /// @return The comparison value for the stencil test function
+        ///
+        s32 GetStencilTestFuncRef() const noexcept { return m_stencilTestFuncRef; }
+        
+        /// @return The mask that is ANDed with the ref and stored value
+        ///
+        u32 GetStencilTestFuncMask() const noexcept { return m_stencilTestFuncMask; }
         
         /// @return The emissive colour
         ///
@@ -161,8 +220,17 @@ namespace ChilliSource
         bool m_isDepthWriteEnabled;
         bool m_isDepthTestEnabled;
         bool m_isFaceCullingEnabled;
+        bool m_isStencilTestEnabled;
+        TestFunc m_depthTestFunc;
         BlendMode m_sourceBlendMode;
         BlendMode m_destinationBlendMode;
+        BlendEqn m_blendEqn;
+        StencilOp m_stencilFailOp;
+        StencilOp m_stencilDepthFailOp;
+        StencilOp m_stencilPassOp;
+        s32 m_stencilTestFuncRef;
+        u32 m_stencilTestFuncMask;
+        TestFunc m_stencilTestFunc;
         CullFace m_cullFace;
         Colour m_emissiveColour;
         Colour m_ambientColour;

--- a/Source/ChilliSource/Rendering/Material/RenderMaterial.h
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterial.h
@@ -67,8 +67,6 @@ namespace ChilliSource
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
-        /// @param blendEqn
-        ///     Describes how the source and destination colours are blended
         /// @param stencilFailOp
         ///     Op applied if stencil test fails
         /// @param stencilDepthFailOp
@@ -97,7 +95,7 @@ namespace ChilliSource
         RenderMaterial(const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
                        bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                        TestFunc depthTestFunc,
-                       BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                       BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                        StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                        CullFace cullFace,
                        const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
@@ -146,10 +144,6 @@ namespace ChilliSource
         /// @return The destination blend mode. This only applies if transparency is enabled.
         ///
         BlendMode GetDestinationBlendMode() const noexcept { return m_destinationBlendMode; }
-        
-        /// @return The equation that describes how source and dest pixels are blended
-        ///
-        BlendEqn GetBlendEqn() const noexcept { return m_blendEqn; }
         
         /// @return The face which should be called. This only applies if face culling is enabled.
         ///
@@ -224,7 +218,6 @@ namespace ChilliSource
         TestFunc m_depthTestFunc;
         BlendMode m_sourceBlendMode;
         BlendMode m_destinationBlendMode;
-        BlendEqn m_blendEqn;
         StencilOp m_stencilFailOp;
         StencilOp m_stencilDepthFailOp;
         StencilOp m_stencilPassOp;

--- a/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.h
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.h
@@ -74,8 +74,6 @@ namespace ChilliSource
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
-        /// @param blendEqn
-        ///     Describes how the source and destination colours are blended
         /// @param stencilFailOp
         ///     Op applied if stencil test fails
         /// @param stencilDepthFailOp
@@ -100,7 +98,7 @@ namespace ChilliSource
         virtual const RenderMaterialGroup* CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture,
                                                                   bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                                                                   TestFunc depthTestFunc,
-                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                                                                   StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                                                   CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept = 0;
         
@@ -151,8 +149,6 @@ namespace ChilliSource
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
-        /// @param blendEqn
-        ///     Describes how the source and destination colours are blended
         /// @param stencilFailOp
         ///     Op applied if stencil test fails
         /// @param stencilDepthFailOp
@@ -183,7 +179,7 @@ namespace ChilliSource
         virtual const RenderMaterialGroup* CreateCustomRenderMaterialGroup(const VertexFormat& vertexFormat, const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
                                                                    bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
                                                                    TestFunc depthTestFunc,
-                                                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode,
                                                                    StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
                                                                    CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
                                                                    RenderShaderVariablesUPtr renderShaderVariables) noexcept = 0;

--- a/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.h
+++ b/Source/ChilliSource/Rendering/Material/RenderMaterialGroupManager.h
@@ -66,10 +66,28 @@ namespace ChilliSource
         ///     Whether or not the depth test will be performed.
         /// @param isFaceCullingEnabled
         ///     Whether or not face culling will be performed.
+        /// @param isStencilTestEnabled
+        ///     Whether or not to perform stencil testing
+        /// @param depthTestFunc
+        ///     Function that determines whether a depth test comparison should pass or fail
         /// @param sourceBlendMode
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
+        /// @param blendEqn
+        ///     Describes how the source and destination colours are blended
+        /// @param stencilFailOp
+        ///     Op applied if stencil test fails
+        /// @param stencilDepthFailOp
+        ///     Op applied if stencil depth test fails
+        /// @param stencilPassOp
+        ///     Op applied if stencil and depth tests pass
+        /// @param stencilTestFunc
+        ///     Function that determines whether a stencil test comparison should pass or fail
+        /// @param stencilRef
+        ///     Value used as comparison for stencil tests
+        /// @param stencilMask
+        ///     Value ANDed to with the comparison and stencil value
         /// @param cullFace
         ///     The face which should be called. This only applies if face culling is enabled.
         /// @param ambientColour
@@ -79,9 +97,12 @@ namespace ChilliSource
         ///
         /// @return The new material group.
         ///
-        virtual const RenderMaterialGroup* CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture, bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled,
-                                                                          bool isDepthTestEnabled, bool isFaceCullingEnabled, BlendMode sourceBlendMode, BlendMode destinationBlendMode, CullFace cullFace,
-                                                                          const Colour& emissiveColour, const Colour& ambientColour) noexcept = 0;
+        virtual const RenderMaterialGroup* CreateUnlitRenderMaterialGroup(const RenderTexture* renderTexture,
+                                                                  bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                                                                  TestFunc depthTestFunc,
+                                                                  BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                  StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
+                                                                  CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour) noexcept = 0;
         
         /// Creates a new blinn RenderMaterialGroup and queues a LoadMaterialGroupRenderCommand for the next
         /// Render Snapshot stage in the render pipeline.
@@ -102,6 +123,7 @@ namespace ChilliSource
         virtual const RenderMaterialGroup* CreateBlinnRenderMaterialGroup(const RenderTexture* renderTexture, const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour,
                                                                           const Colour& specularColour) noexcept = 0;
         
+        
         /// Creates a new custom RenderMaterialGroup and queues a LoadMaterialGroupRenderCommand for the next
         /// Render Snapshot stage in the render pipeline.
         ///
@@ -121,15 +143,33 @@ namespace ChilliSource
         ///     Whether or not the depth test will be performed.
         /// @param isFaceCullingEnabled
         ///     Whether or not face culling will be performed.
+        /// @param isStencilTestEnabled
+        ///     Whether or not to perform stencil testing
+        /// @param depthTestFunc
+        ///     Function that determines whether a depth test comparison should pass or fail
         /// @param sourceBlendMode
         ///     The source blend mode. This only applies if transparency is enabled.
         /// @param destinationBlendMode
         ///     The destination blend mode. This only applies if transparency is enabled.
+        /// @param blendEqn
+        ///     Describes how the source and destination colours are blended
+        /// @param stencilFailOp
+        ///     Op applied if stencil test fails
+        /// @param stencilDepthFailOp
+        ///     Op applied if stencil depth test fails
+        /// @param stencilPassOp
+        ///     Op applied if stencil and depth tests pass
+        /// @param stencilTestFunc
+        ///     Function that determines whether a stencil test comparison should pass or fail
+        /// @param stencilRef
+        ///     Value used as comparison for stencil tests
+        /// @param stencilMask
+        ///     Value ANDed to with the comparison and stencil value
         /// @param cullFace
         ///     The face which should be called. This only applies if face culling is enabled.
-        /// @param ambientColour
-        ///     The ambient colour.
         /// @param emissiveColour
+        ///     The ambient colour.
+        /// @param ambientColour
         ///     The ambient colour.
         /// @param diffuseColour
         ///     The diffuse colour.
@@ -140,10 +180,13 @@ namespace ChilliSource
         ///
         /// @return The new material group.
         ///
-        virtual const RenderMaterialGroup* CreateCustomRenderMaterialGroup(const VertexFormat& vertexFormat, const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures, bool isTransparencyEnabled,
-                                                                           bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, BlendMode sourceBlendMode,
-                                                                           BlendMode destinationBlendMode, CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour,
-                                                                           const Colour& specularColour, RenderShaderVariablesUPtr renderShaderVariables) noexcept = 0;
+        virtual const RenderMaterialGroup* CreateCustomRenderMaterialGroup(const VertexFormat& vertexFormat, const RenderShader* renderShader, const std::vector<const RenderTexture*>& renderTextures,
+                                                                   bool isTransparencyEnabled, bool isColourWriteEnabled, bool isDepthWriteEnabled, bool isDepthTestEnabled, bool isFaceCullingEnabled, bool isStencilTestEnabled,
+                                                                   TestFunc depthTestFunc,
+                                                                   BlendMode sourceBlendMode, BlendMode destinationBlendMode, BlendEqn blendEqn,
+                                                                   StencilOp stencilFailOp, StencilOp stencilDepthFailOp, StencilOp stencilPassOp, TestFunc stencilTestFunc, s32 stencilRef, u32 stencilMask,
+                                                                   CullFace cullFace, const Colour& emissiveColour, const Colour& ambientColour, const Colour& diffuseColour, const Colour& specularColour,
+                                                                   RenderShaderVariablesUPtr renderShaderVariables) noexcept = 0;
         
         /// Removes the RenderMaterialGroup from the manager and queues an UnloadMaterialGroupRenderCommand
         /// for the next Render Snapshot stage in the render pipeline. The render command is given ownership

--- a/Source/ChilliSource/Rendering/Target/RenderTargetGroup.cpp
+++ b/Source/ChilliSource/Rendering/Target/RenderTargetGroup.cpp
@@ -29,8 +29,8 @@
 namespace ChilliSource
 {
     //------------------------------------------------------------------------------
-    RenderTargetGroup::RenderTargetGroup(const RenderTexture* colourTarget, const RenderTexture* depthTarget, bool shouldUseDepthBuffer) noexcept
-        : m_colourTarget(colourTarget), m_depthTarget(depthTarget), m_shouldUseDepthBuffer(shouldUseDepthBuffer)
+    RenderTargetGroup::RenderTargetGroup(const RenderTexture* colourTarget, const RenderTexture* depthTarget, RenderTargetGroupType type) noexcept
+        : m_colourTarget(colourTarget), m_depthTarget(depthTarget), m_type(type)
     {
         CS_ASSERT(colourTarget || depthTarget, "Must supply either a colour target or a depth target.");
         
@@ -53,7 +53,7 @@ namespace ChilliSource
             CS_ASSERT(depthTarget->GetImageFormat() == ImageFormat::k_Depth16 || depthTarget->GetImageFormat() == ImageFormat::k_Depth32, "Depth target must be depth texture.");
             CS_ASSERT(depthTarget->GetImageCompression() == ImageCompression::k_none, "Depth target cannot be compressed.");
             CS_ASSERT(depthTarget->IsMipmapped() == false, "Depth target cannot be mipmapped.");
-            CS_ASSERT(!m_shouldUseDepthBuffer, "If a depth target is supplied, shouldUseDepthBuffer must be false.");
+            CS_ASSERT(m_type == RenderTargetGroupType::k_colour, "If a depth target is supplied, type must be colour only.");
             
             m_resolution = depthTarget->GetDimensions();
         }

--- a/Source/ChilliSource/Rendering/Target/RenderTargetGroup.h
+++ b/Source/ChilliSource/Rendering/Target/RenderTargetGroup.h
@@ -30,6 +30,13 @@
 
 namespace ChilliSource
 {
+    enum class RenderTargetGroupType
+    {
+        k_colour,
+        k_colourDepth,
+        k_colourDepthStencil
+    };
+    
     /// Represents a group of colour and depth render targets that can be bound for rendering.
     /// There are two types of render target: colour and depth. Fragment colour data will be
     /// written to the colour target, while fragment depth data will be written to the depth
@@ -41,6 +48,7 @@ namespace ChilliSource
     class RenderTargetGroup final
     {
     public:
+        
         CS_DECLARE_NOCOPY(RenderTargetGroup);
         
         /// @return The colour render target. Can be null if no colour target is needed.
@@ -54,7 +62,12 @@ namespace ChilliSource
         /// @return Whether or not to use an internal depth buffer if no depth target was specified.
         ///     This should always be false if a depth target was supplied.
         ///
-        bool ShouldUseDepthBuffer() const noexcept { return m_shouldUseDepthBuffer; }
+        bool ShouldUseDepthBuffer() const noexcept { return m_type == RenderTargetGroupType::k_colourDepth || m_type == RenderTargetGroupType::k_colourDepthStencil; }
+        
+        /// @return Whether or not to use an internal stencil buffer.
+        ///     This should always be false if not using a depth buffer.
+        ///
+        bool ShouldUseStencilBuffer() const noexcept { return m_type == RenderTargetGroupType::k_colourDepthStencil; }
         
         /// @return The resolution of the render target.
         ///
@@ -83,15 +96,15 @@ namespace ChilliSource
         ///     The colour render target. Can be null if no colour target is needed.
         /// @param depthTarget
         ///     The depth render target. Can be null if no depth target is needed.
-        /// @param shouldUseDepthBuffer
-        ///     Whether or not to use an internal depth buffer if no depth buffer was specified.
-        ///     This should always be false if a depth target was supplied.
+        /// @param type
+        ///     Whether or not to use an internal depth buffer or stencil buffer.
+        ///     NOTE: Stencil requires depth and type must be colour only if explicit depth target is supplied
         ///
-        RenderTargetGroup(const RenderTexture* colourTarget, const RenderTexture* depthTarget, bool shouldUseDepthBuffer) noexcept;
+        RenderTargetGroup(const RenderTexture* colourTarget, const RenderTexture* depthTarget, RenderTargetGroupType type) noexcept;
         
         const RenderTexture* m_colourTarget;
         const RenderTexture* m_depthTarget;
-        bool m_shouldUseDepthBuffer;
+        RenderTargetGroupType m_type;
         Integer2 m_resolution;
         void* m_extraData = nullptr;
     };

--- a/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.cpp
+++ b/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.cpp
@@ -48,7 +48,7 @@ namespace ChilliSource
         CS_ASSERT(colourTarget, "Must supply a colour target.");
         CS_ASSERT(depthTarget, "Must supply a depth target.");
         
-        RenderTargetGroupUPtr tenderTargetGroup(new RenderTargetGroup(colourTarget, depthTarget, false));
+        RenderTargetGroupUPtr tenderTargetGroup(new RenderTargetGroup(colourTarget, depthTarget, RenderTargetGroupType::k_colour));
         auto tenderTargetGroupRaw = tenderTargetGroup.get();
         AddRenderTargetGroup(std::move(tenderTargetGroup));
         
@@ -56,11 +56,11 @@ namespace ChilliSource
     }
 
     //------------------------------------------------------------------------------
-    const RenderTargetGroup* RenderTargetGroupManager::CreateColourRenderTargetGroup(const RenderTexture* colourTarget, bool shouldUseDepthBuffer) noexcept
+    const RenderTargetGroup* RenderTargetGroupManager::CreateColourRenderTargetGroup(const RenderTexture* colourTarget, RenderTargetGroupType type) noexcept
     {
         CS_ASSERT(colourTarget, "Must supply a colour target.");
         
-        RenderTargetGroupUPtr tenderTargetGroup(new RenderTargetGroup(colourTarget, nullptr, shouldUseDepthBuffer));
+        RenderTargetGroupUPtr tenderTargetGroup(new RenderTargetGroup(colourTarget, nullptr, type));
         auto tenderTargetGroupRaw = tenderTargetGroup.get();
         AddRenderTargetGroup(std::move(tenderTargetGroup));
         
@@ -72,7 +72,7 @@ namespace ChilliSource
     {
         CS_ASSERT(depthTarget, "Must supply a depth target.");
         
-        RenderTargetGroupUPtr tenderTargetGroup(new RenderTargetGroup(nullptr, depthTarget, false));
+        RenderTargetGroupUPtr tenderTargetGroup(new RenderTargetGroup(nullptr, depthTarget, RenderTargetGroupType::k_colour));
         auto tenderTargetGroupRaw = tenderTargetGroup.get();
         AddRenderTargetGroup(std::move(tenderTargetGroup));
         

--- a/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.h
+++ b/Source/ChilliSource/Rendering/Target/RenderTargetGroupManager.h
@@ -80,12 +80,12 @@ namespace ChilliSource
         ///
         /// @param colourTarget
         ///     The texture that will be used as the colour target. must not be null.
-        /// @param shouldUseDepthBuffer
-        ///     Whether or not an internal, efficient, depth buffer should be used.
+        /// @param type
+        ///     Whether or not an internal, efficient, depth buffer or stencil buffer should be used.
         ///
         /// @return The new render target group instance.
         ///
-        const RenderTargetGroup* CreateColourRenderTargetGroup(const RenderTexture* colourTarget, bool shouldUseDepthBuffer = true) noexcept;
+        const RenderTargetGroup* CreateColourRenderTargetGroup(const RenderTexture* colourTarget, RenderTargetGroupType type) noexcept;
         
         /// Creates a new depth only RenderTargetGroup and queues a LoadTargetGroupRenderCommand for the next
         /// RenderSnapshot stage in the render pipeline.

--- a/Source/ChilliSource/Rendering/Target/TargetGroup.cpp
+++ b/Source/ChilliSource/Rendering/Target/TargetGroup.cpp
@@ -38,11 +38,10 @@ namespace ChilliSource
         ///     The colour render target. Can be null if no colour target is needed.
         /// @param depthTarget
         ///     The depth render target. Can be null if no depth target is needed.
-        /// @param shouldUseDepthBuffer
-        ///     Whether or not to use an internal depth buffer if no depth buffer was specified.
-        ///     This should always be false if a depth target was supplied.
+        /// @param type
+        ///    Whether or not an internal, efficient, depth or stencil buffer should be used.
         ///
-        const RenderTargetGroup* CreateRenderTargetGroup(const RenderTexture* colourTarget, const RenderTexture* depthTarget, bool shouldUseDepthBuffer)
+        const RenderTargetGroup* CreateRenderTargetGroup(const RenderTexture* colourTarget, const RenderTexture* depthTarget, RenderTargetGroupType type)
         {
             auto renderTargetGroupManager = Application::Get()->GetSystem<RenderTargetGroupManager>();
             if (colourTarget && depthTarget)
@@ -51,7 +50,7 @@ namespace ChilliSource
             }
             else if (colourTarget)
             {
-                return renderTargetGroupManager->CreateColourRenderTargetGroup(colourTarget, shouldUseDepthBuffer);
+                return renderTargetGroupManager->CreateColourRenderTargetGroup(colourTarget, type);
             }
             else if (depthTarget)
             {
@@ -65,19 +64,19 @@ namespace ChilliSource
     //------------------------------------------------------------------------------
     TargetGroupUPtr TargetGroup::CreateTargetGroup(const TextureCSPtr& colourTarget, const TextureCSPtr& depthTarget) noexcept
     {
-        return TargetGroupUPtr(new TargetGroup(colourTarget, depthTarget, false));
+        return TargetGroupUPtr(new TargetGroup(colourTarget, depthTarget, RenderTargetGroupType::k_colour));
     }
     
     //------------------------------------------------------------------------------
-    TargetGroupUPtr TargetGroup::CreateColourTargetGroup(const TextureCSPtr& colourTarget, bool shouldUseDepthBuffer) noexcept
+    TargetGroupUPtr TargetGroup::CreateColourTargetGroup(const TextureCSPtr& colourTarget, RenderTargetGroupType type) noexcept
     {
-        return TargetGroupUPtr(new TargetGroup(colourTarget, nullptr, shouldUseDepthBuffer));
+        return TargetGroupUPtr(new TargetGroup(colourTarget, nullptr, type));
     }
     
     //------------------------------------------------------------------------------
     TargetGroupUPtr TargetGroup::CreateDepthTargetGroup(const TextureCSPtr& depthTarget) noexcept
     {
-        return TargetGroupUPtr(new TargetGroup(nullptr, depthTarget, false));
+        return TargetGroupUPtr(new TargetGroup(nullptr, depthTarget, RenderTargetGroupType::k_colour));
     }
     
     //------------------------------------------------------------------------------
@@ -92,7 +91,7 @@ namespace ChilliSource
             m_cachedColourTargetRenderTexture = m_cachedColourTargetTexture == nullptr ? nullptr : m_cachedColourTargetTexture->GetRenderTexture();
             m_cachedDepthTargetRenderTexture = m_cachedDepthTargetTexture == nullptr ? nullptr : m_cachedDepthTargetTexture->GetRenderTexture();
             
-            m_renderTargetGroup = CreateRenderTargetGroup(m_cachedColourTargetRenderTexture, m_cachedDepthTargetRenderTexture, m_shouldUseDepthBuffer);
+            m_renderTargetGroup = CreateRenderTargetGroup(m_cachedColourTargetRenderTexture, m_cachedDepthTargetRenderTexture, m_type);
         }
         
         return m_renderTargetGroup;
@@ -122,13 +121,13 @@ namespace ChilliSource
     }
     
     //------------------------------------------------------------------------------
-    TargetGroup::TargetGroup(const TextureCSPtr& colourTarget, const TextureCSPtr& depthTarget, bool shouldUseDepthBuffer) noexcept
-        : m_cachedColourTargetTexture(colourTarget), m_cachedDepthTargetTexture(depthTarget), m_shouldUseDepthBuffer(shouldUseDepthBuffer)
+    TargetGroup::TargetGroup(const TextureCSPtr& colourTarget, const TextureCSPtr& depthTarget, RenderTargetGroupType type) noexcept
+        : m_cachedColourTargetTexture(colourTarget), m_cachedDepthTargetTexture(depthTarget), m_type(type)
     {
         m_cachedColourTargetRenderTexture = colourTarget == nullptr ? nullptr : colourTarget->GetRenderTexture();
         m_cachedDepthTargetRenderTexture = depthTarget == nullptr ? nullptr : depthTarget->GetRenderTexture();
         
-        m_renderTargetGroup = CreateRenderTargetGroup(m_cachedColourTargetRenderTexture, m_cachedDepthTargetRenderTexture, m_shouldUseDepthBuffer);
+        m_renderTargetGroup = CreateRenderTargetGroup(m_cachedColourTargetRenderTexture, m_cachedDepthTargetRenderTexture, type);
     }
     
     //------------------------------------------------------------------------------

--- a/Source/ChilliSource/Rendering/Target/TargetGroup.h
+++ b/Source/ChilliSource/Rendering/Target/TargetGroup.h
@@ -59,11 +59,11 @@ namespace ChilliSource
         /// @param colourTarget
         ///     The texture that will be used as the colour target. must not be null.
         /// @param shouldUseDepthBuffer
-        ///     Whether or not an internal, efficient, depth buffer should be used.
+        ///     Whether or not an internal, efficient, depth or stencil buffer should be used.
         ///
         /// @return The new render group instance.
         ///
-        static TargetGroupUPtr CreateColourTargetGroup(const TextureCSPtr& colourTarget, bool shouldUseDepthBuffer = true) noexcept;
+        static TargetGroupUPtr CreateColourTargetGroup(const TextureCSPtr& colourTarget, RenderTargetGroupType type) noexcept;
         
         /// Creates a new depth only TargetGroup
         ///
@@ -90,11 +90,10 @@ namespace ChilliSource
         ///     The colour render target. Can be null if no colour target is needed.
         /// @param depthTarget
         ///     The depth render target. Can be null if no depth target is needed.
-        /// @param shouldUseDepthBuffer
-        ///     Whether or not to use an internal depth buffer if no depth buffer was specified.
-        ///     This should always be false if a depth target was supplied.
+        /// @param type
+        ///     Whether or not an internal, efficient, depth or stencil buffer should be used.
         ///
-        TargetGroup(const TextureCSPtr& colourTarget, const TextureCSPtr& depthTarget, bool shouldUseDepthBuffer) noexcept;
+        TargetGroup(const TextureCSPtr& colourTarget, const TextureCSPtr& depthTarget, RenderTargetGroupType type) noexcept;
         
         /// Destroys the render target group if there is one.
         ///
@@ -110,7 +109,7 @@ namespace ChilliSource
         const RenderTexture* m_cachedColourTargetRenderTexture = nullptr;
         const RenderTexture* m_cachedDepthTargetRenderTexture = nullptr;
         
-        bool m_shouldUseDepthBuffer = true;
+        RenderTargetGroupType m_type;
     };
 }
 

--- a/Source/ChilliSource/UI/Base/UIComponent.h
+++ b/Source/ChilliSource/UI/Base/UIComponent.h
@@ -227,6 +227,18 @@ namespace ChilliSource
         //----------------------------------------------------------------
         virtual void OnDraw(CanvasRenderer* in_renderer, const Matrix3& in_transform, const Vector2& in_absSize, const Colour& in_absColour) {}
         //----------------------------------------------------------------
+        /// Called prior to the widget drawing its children
+        ///
+        /// @param The canvas renderer.
+        //----------------------------------------------------------------
+        virtual void OnPreDrawChildren(CanvasRenderer* in_renderer) {}
+        //----------------------------------------------------------------
+        /// Called after the widget draws its children
+        ///
+        /// @param The canvas renderer.
+        //----------------------------------------------------------------
+        virtual void OnPostDrawChildren(CanvasRenderer* in_renderer) {}
+        //----------------------------------------------------------------
         /// This is called when the application is backgrounded while the
         /// owning widget is on the canvas. This will also be called when
         /// the owning widget is removed from the canvas if the application

--- a/Source/ChilliSource/UI/Base/Widget.cpp
+++ b/Source/ChilliSource/UI/Base/Widget.cpp
@@ -58,7 +58,6 @@ namespace ChilliSource
         const char k_properyNameOriginAnchor[] = "originanchor";
         const char k_properyNameParentalAnchor[] = "parentalanchor";
         const char k_properyNameVisible[] = "visible";
-        const char k_properyNameClipChildren[] = "clipchildren";
         const char k_properyNameInputEnabled[] = "inputenabled";
         const char k_properyNameInputConsumeEnabled[] = "inputconsumeenabled";
         const char k_properyNameSizePolicy[] = "sizepolicy";
@@ -77,7 +76,6 @@ namespace ChilliSource
             {PropertyTypes::AlignmentAnchor(), k_properyNameOriginAnchor},
             {PropertyTypes::AlignmentAnchor(), k_properyNameParentalAnchor},
             {PropertyTypes::Bool(), k_properyNameVisible},
-            {PropertyTypes::Bool(), k_properyNameClipChildren},
             {PropertyTypes::Bool(), k_properyNameInputEnabled},
             {PropertyTypes::Bool(), k_properyNameInputConsumeEnabled},
             {PropertyTypes::SizePolicy(), k_properyNameSizePolicy},
@@ -262,7 +260,6 @@ namespace ChilliSource
         m_baseProperties.emplace(k_properyNameOriginAnchor, PropertyTypes::AlignmentAnchor()->CreateProperty(MakeDelegate(this, &Widget::GetOriginAnchor), MakeDelegate(this, &Widget::SetOriginAnchor)));
         m_baseProperties.emplace(k_properyNameParentalAnchor, PropertyTypes::AlignmentAnchor()->CreateProperty(MakeDelegate(this, &Widget::GetParentalAnchor), MakeDelegate(this, &Widget::SetParentalAnchor)));
         m_baseProperties.emplace(k_properyNameVisible, PropertyTypes::Bool()->CreateProperty(MakeDelegate(this, &Widget::IsVisible), MakeDelegate(this, &Widget::SetVisible)));
-        m_baseProperties.emplace(k_properyNameClipChildren, PropertyTypes::Bool()->CreateProperty(MakeDelegate(this, &Widget::IsClippingEnabled), MakeDelegate(this, &Widget::SetClippingEnabled)));
         m_baseProperties.emplace(k_properyNameInputEnabled, PropertyTypes::Bool()->CreateProperty(MakeDelegate(this, &Widget::IsInputEnabled), MakeDelegate(this, &Widget::SetInputEnabled)));
         m_baseProperties.emplace(k_properyNameInputConsumeEnabled, PropertyTypes::Bool()->CreateProperty(MakeDelegate(this, &Widget::IsInputConsumeEnabled), MakeDelegate(this, &Widget::SetInputConsumeEnabled)));
         m_baseProperties.emplace(k_properyNameSizePolicy, PropertyTypes::SizePolicy()->CreateProperty(MakeDelegate(this, &Widget::GetSizePolicy), MakeDelegate(this, &Widget::SetSizePolicy)));
@@ -654,18 +651,6 @@ namespace ChilliSource
     bool Widget::IsVisible() const
     {
         return m_isVisible;
-    }
-    //----------------------------------------------------------------------------------------
-    //----------------------------------------------------------------------------------------
-    void Widget::SetClippingEnabled(bool in_enabled)
-    {
-        m_isSubviewClippingEnabled = in_enabled;
-    }
-    //----------------------------------------------------------------------------------------
-    //----------------------------------------------------------------------------------------
-    bool Widget::IsClippingEnabled() const
-    {
-        return m_isSubviewClippingEnabled;
     }
     //----------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------
@@ -1488,12 +1473,9 @@ namespace ChilliSource
             }
         }
         
-        if(m_isSubviewClippingEnabled == true)
+        for (auto& component : m_components)
         {
-            Vector2 bottomLeftPos = GetAnchorPoint(AlignmentAnchor::k_bottomLeft, finalSize * 0.5f);
-            bottomLeftPos += GetFinalPositionOfCentre();
-            
-            in_renderer->PushClipBounds(bottomLeftPos, finalSize);
+            component->OnPreDrawChildren(in_renderer);
         }
         
         m_internalChildren.lock();
@@ -1510,9 +1492,9 @@ namespace ChilliSource
         }
         m_children.unlock();
         
-        if(m_isSubviewClippingEnabled == true)
+        for (auto& component : m_components)
         {
-            in_renderer->PopClipBounds();
+            component->OnPostDrawChildren(in_renderer);
         }
     }
     //----------------------------------------------------------------------------------------

--- a/Source/ChilliSource/UI/Base/Widget.h
+++ b/Source/ChilliSource/UI/Base/Widget.h
@@ -88,8 +88,6 @@ namespace ChilliSource
     ///
     /// "Visible": A boolean describing whether or not the widget and it's children are visible.
     ///
-    /// "ClipChildren": A boolean describing whether children that exceed bounds are clipped.
-    ///
     /// "OriginAnchor": The anchor point of the widgets origin. Possible values are: 'TopLeft',
     /// 'TopCentre', 'TopRight', 'MiddleLeft', 'MiddleCentre', 'MiddleRight', 'BottomLeft',
     /// 'BottomCentre', 'BottomRight'
@@ -461,20 +459,6 @@ namespace ChilliSource
         /// @return Whether the widget hierarchy from here down is visible
         //----------------------------------------------------------------------------------------
         bool IsVisible() const;
-        //----------------------------------------------------------------------------------------
-        /// NOTE: Clipping does not work well with rotation as it requires an AABB clip region
-        ///
-        /// @author S Downie
-        ///
-        /// @param Set whether the widget will clip pixels that exceed its bounds
-        //----------------------------------------------------------------------------------------
-        void SetClippingEnabled(bool in_enabled);
-        //----------------------------------------------------------------------------------------
-        /// @author S Downie
-        ///
-        /// @return Set whether the widget will clip pixels that exceed its bounds
-        //----------------------------------------------------------------------------------------
-        bool IsClippingEnabled() const;
         //----------------------------------------------------------------------------------------
         /// @author S Downie
         ///
@@ -1265,7 +1249,6 @@ namespace ChilliSource
         UnifiedVector2 m_originPosition;
         
         bool m_isVisible = true;
-        bool m_isSubviewClippingEnabled = false;
         bool m_isInputEnabled = true;
         bool m_isInputConsumeEnabled = false;
         

--- a/Source/ChilliSource/UI/Drawable/DrawableUIComponent.cpp
+++ b/Source/ChilliSource/UI/Drawable/DrawableUIComponent.cpp
@@ -29,6 +29,7 @@
 #include <ChilliSource/UI/Drawable/DrawableUIComponent.h>
 
 #include <ChilliSource/Core/Delegate/MakeDelegate.h>
+#include <ChilliSource/Rendering/Base/CanvasRenderer.h>
 #include <ChilliSource/UI/Base/PropertyTypes.h>
 #include <ChilliSource/UI/Drawable/UIDrawable.h>
 #include <ChilliSource/UI/Drawable/UIDrawableDef.h>
@@ -102,7 +103,25 @@ namespace ChilliSource
     {
         if (m_drawable != nullptr)
         {
-            m_drawable->Draw(in_renderer, in_transform, in_absSize, in_absColour);
+            m_drawable->Draw(in_renderer, in_transform, in_absSize, in_absColour, m_drawableDef->IsMask());
+        }
+    }
+    //----------------------------------------------------------------
+    //----------------------------------------------------------------
+    void DrawableUIComponent::OnPreDrawChildren(CanvasRenderer* in_renderer)
+    {
+        if(m_drawable != nullptr && m_drawableDef->IsMask())
+        {
+            in_renderer->IncrementClipMask();
+        }
+    }
+    //----------------------------------------------------------------
+    //----------------------------------------------------------------
+    void DrawableUIComponent::OnPostDrawChildren(CanvasRenderer* in_renderer)
+    {
+        if(m_drawable != nullptr && m_drawableDef->IsMask())
+        {
+            in_renderer->DecrementClipMask();
         }
     }
 }

--- a/Source/ChilliSource/UI/Drawable/DrawableUIComponent.cpp
+++ b/Source/ChilliSource/UI/Drawable/DrawableUIComponent.cpp
@@ -29,6 +29,7 @@
 #include <ChilliSource/UI/Drawable/DrawableUIComponent.h>
 
 #include <ChilliSource/Core/Delegate/MakeDelegate.h>
+#include <ChilliSource/Rendering/Base/CanvasDrawMode.h>
 #include <ChilliSource/Rendering/Base/CanvasRenderer.h>
 #include <ChilliSource/UI/Base/PropertyTypes.h>
 #include <ChilliSource/UI/Drawable/UIDrawable.h>
@@ -103,14 +104,16 @@ namespace ChilliSource
     {
         if (m_drawable != nullptr)
         {
-            m_drawable->Draw(in_renderer, in_transform, in_absSize, in_absColour, m_drawableDef->IsMask());
+            m_drawable->Draw(in_renderer, in_transform, in_absSize, in_absColour, m_drawableDef->GetDrawMode());
         }
     }
     //----------------------------------------------------------------
     //----------------------------------------------------------------
     void DrawableUIComponent::OnPreDrawChildren(CanvasRenderer* in_renderer)
     {
-        if(m_drawable != nullptr && m_drawableDef->IsMask())
+        auto drawMode = m_drawableDef->GetDrawMode();
+        
+        if(m_drawable != nullptr && (drawMode == CanvasDrawMode::k_mask || drawMode == CanvasDrawMode::k_maskOnly))
         {
             in_renderer->IncrementClipMask();
         }
@@ -119,7 +122,9 @@ namespace ChilliSource
     //----------------------------------------------------------------
     void DrawableUIComponent::OnPostDrawChildren(CanvasRenderer* in_renderer)
     {
-        if(m_drawable != nullptr && m_drawableDef->IsMask())
+        auto drawMode = m_drawableDef->GetDrawMode();
+        
+        if(m_drawable != nullptr && (drawMode == CanvasDrawMode::k_mask || drawMode == CanvasDrawMode::k_maskOnly))
         {
             in_renderer->DecrementClipMask();
         }

--- a/Source/ChilliSource/UI/Drawable/DrawableUIComponent.h
+++ b/Source/ChilliSource/UI/Drawable/DrawableUIComponent.h
@@ -135,8 +135,23 @@ namespace ChilliSource
         /// @param The final screen space transform.
         /// @param The final screen space size.
         /// @param The final colour.
+        /// @param Number of the layer in the UI hierarchy
         //----------------------------------------------------------------
         void OnDraw(CanvasRenderer* in_renderer, const Matrix3& in_transform, const Vector2& in_absSize, const Colour& in_absColour) override;
+        //----------------------------------------------------------------
+        /// Called prior to the widget drawing its children. Used for
+        /// setting up subview clipping
+        ///
+        /// @param The canvas renderer.
+        //----------------------------------------------------------------
+        void OnPreDrawChildren(CanvasRenderer* in_renderer) override;
+        //----------------------------------------------------------------
+        /// Called after the widget draws its children. Used for cleaning
+        /// up subview clipping
+        ///
+        /// @param The canvas renderer.
+        //----------------------------------------------------------------
+        void OnPostDrawChildren(CanvasRenderer* in_renderer) override;
         
         UIDrawableDefCSPtr m_drawableDef;
         UIDrawableUPtr m_drawable;

--- a/Source/ChilliSource/UI/Drawable/NinePatchUIDrawable.cpp
+++ b/Source/ChilliSource/UI/Drawable/NinePatchUIDrawable.cpp
@@ -529,21 +529,10 @@ namespace ChilliSource
         
         UpdatePatchCache(absSize);
         
-        if(toMask == false)
+        for(u32 i=0; i<k_numPatches; ++i)
         {
-            for(u32 i=0; i<k_numPatches; ++i)
-            {
-                Matrix3 patchTransform = Matrix3::CreateTranslation(m_cachedPositions[i]);
-                renderer->DrawBox(patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], absColour * m_colour, AlignmentAnchor::k_middleCentre);
-            }
-        }
-        else
-        {
-            for(u32 i=0; i<k_numPatches; ++i)
-            {
-                Matrix3 patchTransform = Matrix3::CreateTranslation(m_cachedPositions[i]);
-                renderer->DrawMaskedBox(patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], AlignmentAnchor::k_middleCentre);
-            }
+            Matrix3 patchTransform = Matrix3::CreateTranslation(m_cachedPositions[i]);
+            renderer->DrawBox(patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], absColour * m_colour, AlignmentAnchor::k_middleCentre, toMask);
         }
     }
 }

--- a/Source/ChilliSource/UI/Drawable/NinePatchUIDrawable.cpp
+++ b/Source/ChilliSource/UI/Drawable/NinePatchUIDrawable.cpp
@@ -523,7 +523,7 @@ namespace ChilliSource
     }
     //----------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------
-    void NinePatchUIDrawable::Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept
+    void NinePatchUIDrawable::Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, CanvasDrawMode drawMode) noexcept
     {
         CS_ASSERT(m_texture != nullptr, "NinePatchUIDrawable cannot draw without texture");
         
@@ -532,7 +532,7 @@ namespace ChilliSource
         for(u32 i=0; i<k_numPatches; ++i)
         {
             Matrix3 patchTransform = Matrix3::CreateTranslation(m_cachedPositions[i]);
-            renderer->DrawBox(patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], absColour * m_colour, AlignmentAnchor::k_middleCentre, toMask);
+            renderer->DrawBox(drawMode, patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], absColour * m_colour, AlignmentAnchor::k_middleCentre);
         }
     }
 }

--- a/Source/ChilliSource/UI/Drawable/NinePatchUIDrawable.h
+++ b/Source/ChilliSource/UI/Drawable/NinePatchUIDrawable.h
@@ -187,10 +187,10 @@ namespace ChilliSource
         ///     Asbolute screen size
         /// @param absColour
         ///     Absolute colour
-        /// @param toMask
-        ///     Whether or not to create a clip mask for this drawable
+        /// @param drawMode
+        ///     Whether or not to create a clip mask for this drawable or just render to screen
         ///
-        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept override;
+        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, CanvasDrawMode drawMode) noexcept override;
         
     private:
         friend class NinePatchUIDrawableDef;

--- a/Source/ChilliSource/UI/Drawable/NinePatchUIDrawable.h
+++ b/Source/ChilliSource/UI/Drawable/NinePatchUIDrawable.h
@@ -176,18 +176,21 @@ namespace ChilliSource
         /// texture size
         //----------------------------------------------------------------------------------------
         Vector2 GetPreferredSize() const override;
-        //----------------------------------------------------------------------------------------
-        /// Render the widget using the canvas renderer. The widget has is rendered using the
-        /// set texture and UVs.
+        
+        /// Render the widget using the canvas renderer.
         ///
-        /// @author S Downie
+        /// @param renderer
+        ///     Performs the actual drawing to canvas
+        /// @param transform
+        ///     Absolute screen transform
+        /// @param absSize
+        ///     Asbolute screen size
+        /// @param absColour
+        ///     Absolute colour
+        /// @param toMask
+        ///     Whether or not to create a clip mask for this drawable
         ///
-        /// @param Renderer
-        /// @param Absolute screen transform
-        /// @param Asbolute screen size
-        /// @param Absolute colour
-        //----------------------------------------------------------------------------------------
-        void Draw(CanvasRenderer* in_renderer, const Matrix3& in_transform, const Vector2& in_absSize, const Colour& in_absColour) override;
+        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept override;
         
     private:
         friend class NinePatchUIDrawableDef;
@@ -217,6 +220,14 @@ namespace ChilliSource
         /// @param The bottom inset.
         //----------------------------------------------------------------------------------------
         NinePatchUIDrawable(const TextureCSPtr& in_texture, const TextureAtlasCSPtr& in_atlas, const std::string& in_atlasId, f32 in_leftInset, f32 in_rightInset, f32 in_topInset, f32 in_bottomInset);
+        
+        /// Patches (size, pos, etc) are calculated and cached. This function when called will
+        /// update the cache if required, otherwise it will do nothing
+        ///
+        /// @param absSize
+        ///     Canvas space size of the widget, if changed from last draw, update the cache
+        ///
+        void UpdatePatchCache(const Vector2& absSize);
         
         TextureCSPtr m_texture;
         TextureAtlasCSPtr m_atlas;

--- a/Source/ChilliSource/UI/Drawable/NinePatchUIDrawableDef.cpp
+++ b/Source/ChilliSource/UI/Drawable/NinePatchUIDrawableDef.cpp
@@ -51,6 +51,7 @@ namespace ChilliSource
         const char k_uvsKey[] = "UVs";
         const char k_colourKey[] = "Colour";
         const char k_insetsKey[] = "Insets";
+        const char k_maskKey[] = "Masking";
         
         CS_ASSERT(in_json.isObject() == true, "UIDrawable Def must be created from a json value of type Object.");
         
@@ -98,6 +99,10 @@ namespace ChilliSource
             else if (key == k_insetsKey)
             {
                 m_insets = ParseVector4(value);
+            }
+            else if (key == k_maskKey)
+            {
+                m_isMask = ParseBool(value);
             }
             else if (key == k_typeKey)
             {

--- a/Source/ChilliSource/UI/Drawable/NinePatchUIDrawableDef.cpp
+++ b/Source/ChilliSource/UI/Drawable/NinePatchUIDrawableDef.cpp
@@ -31,6 +31,7 @@
 #include <ChilliSource/Core/Base/Application.h>
 #include <ChilliSource/Core/Resource/ResourcePool.h>
 #include <ChilliSource/Core/String/StringParser.h>
+#include <ChilliSource/Rendering/Base/CanvasDrawMode.h>
 #include <ChilliSource/Rendering/Texture/Texture.h>
 #include <ChilliSource/Rendering/Texture/TextureAtlas.h>
 #include <ChilliSource/UI/Drawable/NinePatchUIDrawable.h>
@@ -41,6 +42,7 @@ namespace ChilliSource
     //--------------------------------------------------------------
     //--------------------------------------------------------------
     NinePatchUIDrawableDef::NinePatchUIDrawableDef(const Json::Value& in_json, StorageLocation in_defaultLocation, const std::string& in_defaultPath)
+    : m_drawMode(CanvasDrawMode::k_standard)
     {
         const char k_typeKey[] = "Type";
         const char k_textureLocationKey[] = "TextureLocation";
@@ -51,7 +53,7 @@ namespace ChilliSource
         const char k_uvsKey[] = "UVs";
         const char k_colourKey[] = "Colour";
         const char k_insetsKey[] = "Insets";
-        const char k_maskKey[] = "Masking";
+        const char k_drawModeKey[] = "DrawMode";
         
         CS_ASSERT(in_json.isObject() == true, "UIDrawable Def must be created from a json value of type Object.");
         
@@ -100,9 +102,9 @@ namespace ChilliSource
             {
                 m_insets = ParseVector4(value);
             }
-            else if (key == k_maskKey)
+            else if (key == k_drawModeKey)
             {
-                m_isMask = ParseBool(value);
+                m_drawMode = ParseCanvasDrawMode(value);
             }
             else if (key == k_typeKey)
             {
@@ -148,7 +150,7 @@ namespace ChilliSource
     //--------------------------------------------------------------
     //--------------------------------------------------------------
     NinePatchUIDrawableDef::NinePatchUIDrawableDef(const TextureCSPtr& in_texture, const Vector4& in_insets, const Colour& in_colour, const UVs& in_uvs)
-        : m_texture(in_texture), m_insets(in_insets), m_colour(in_colour), m_uvs(in_uvs)
+    : m_texture(in_texture), m_insets(in_insets), m_colour(in_colour), m_uvs(in_uvs), m_drawMode(CanvasDrawMode::k_standard)
     {
         CS_ASSERT(m_texture != nullptr, "The texture cannot be null in a Nine-Patch UIDrawable Def.");
     }
@@ -156,7 +158,7 @@ namespace ChilliSource
     //--------------------------------------------------------------
     NinePatchUIDrawableDef::NinePatchUIDrawableDef(const TextureCSPtr& in_texture, const TextureAtlasCSPtr& in_atlas, const std::string& in_atlasId, const Vector4& in_insets,
                                                const Colour& in_colour, const UVs& in_uvs)
-        : m_texture(in_texture), m_atlas(in_atlas), m_atlasId(in_atlasId), m_insets(in_insets), m_colour(in_colour), m_uvs(in_uvs)
+    : m_texture(in_texture), m_atlas(in_atlas), m_atlasId(in_atlasId), m_insets(in_insets), m_colour(in_colour), m_uvs(in_uvs), m_drawMode(CanvasDrawMode::k_standard)
     {
         CS_ASSERT(m_texture != nullptr, "The texture cannot be null in a Nine-Patch UIDrawable Def.");
         CS_ASSERT(m_atlas != nullptr, "Cannot specify a null texture atlas in a Nine-Patch UIDrawable Def. Use the texture only constructor instead.");

--- a/Source/ChilliSource/UI/Drawable/NinePatchUIDrawableDef.h
+++ b/Source/ChilliSource/UI/Drawable/NinePatchUIDrawableDef.h
@@ -159,9 +159,9 @@ namespace ChilliSource
         //--------------------------------------------------------------
         const Vector4& GetInsets() const;
         
-        /// @return Whether the drawable creates a clipping mask
+        /// @return Draw mode of the drawable
         ///
-        bool IsMask() const noexcept override { return m_isMask; }
+        CanvasDrawMode GetDrawMode() const noexcept override { return m_drawMode; }
         
     private:
         //--------------------------------------------------------------
@@ -181,7 +181,7 @@ namespace ChilliSource
         UVs m_uvs;
         Colour m_colour;
         Vector4 m_insets;
-        bool m_isMask = false;
+        CanvasDrawMode m_drawMode;
     };
 }
 

--- a/Source/ChilliSource/UI/Drawable/NinePatchUIDrawableDef.h
+++ b/Source/ChilliSource/UI/Drawable/NinePatchUIDrawableDef.h
@@ -159,6 +159,10 @@ namespace ChilliSource
         //--------------------------------------------------------------
         const Vector4& GetInsets() const;
         
+        /// @return Whether the drawable creates a clipping mask
+        ///
+        bool IsMask() const noexcept override { return m_isMask; }
+        
     private:
         //--------------------------------------------------------------
         /// Creates a new instance of a standard drawable as described
@@ -177,6 +181,7 @@ namespace ChilliSource
         UVs m_uvs;
         Colour m_colour;
         Vector4 m_insets;
+        bool m_isMask = false;
     };
 }
 

--- a/Source/ChilliSource/UI/Drawable/StandardUIDrawable.cpp
+++ b/Source/ChilliSource/UI/Drawable/StandardUIDrawable.cpp
@@ -181,10 +181,10 @@ namespace ChilliSource
     }
     //----------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------
-    void StandardUIDrawable::Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept
+    void StandardUIDrawable::Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, CanvasDrawMode drawMode) noexcept
     {
         CS_ASSERT(m_texture != nullptr, "StandardUIDrawable cannot draw without texture");
 
-        renderer->DrawBox(transform, CalculateAlphaRestoreSize(m_atlasFrame, absSize), CalculateAlphaRestoreOffset(m_atlasFrame, absSize), m_texture, m_atlasFrame.m_uvs, absColour * m_colour, AlignmentAnchor::k_middleCentre, toMask);
+        renderer->DrawBox(drawMode, transform, CalculateAlphaRestoreSize(m_atlasFrame, absSize), CalculateAlphaRestoreOffset(m_atlasFrame, absSize), m_texture, m_atlasFrame.m_uvs, absColour * m_colour, AlignmentAnchor::k_middleCentre);
     }
 }

--- a/Source/ChilliSource/UI/Drawable/StandardUIDrawable.cpp
+++ b/Source/ChilliSource/UI/Drawable/StandardUIDrawable.cpp
@@ -184,13 +184,7 @@ namespace ChilliSource
     void StandardUIDrawable::Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept
     {
         CS_ASSERT(m_texture != nullptr, "StandardUIDrawable cannot draw without texture");
-        if(toMask == false)
-        {
-            renderer->DrawBox(transform, CalculateAlphaRestoreSize(m_atlasFrame, absSize), CalculateAlphaRestoreOffset(m_atlasFrame, absSize), m_texture, m_atlasFrame.m_uvs, absColour * m_colour, AlignmentAnchor::k_middleCentre);
-        }
-        else
-        {
-            renderer->DrawMaskedBox(transform, CalculateAlphaRestoreSize(m_atlasFrame, absSize), CalculateAlphaRestoreOffset(m_atlasFrame, absSize), m_texture, m_atlasFrame.m_uvs, AlignmentAnchor::k_middleCentre);
-        }
+
+        renderer->DrawBox(transform, CalculateAlphaRestoreSize(m_atlasFrame, absSize), CalculateAlphaRestoreOffset(m_atlasFrame, absSize), m_texture, m_atlasFrame.m_uvs, absColour * m_colour, AlignmentAnchor::k_middleCentre, toMask);
     }
 }

--- a/Source/ChilliSource/UI/Drawable/StandardUIDrawable.h
+++ b/Source/ChilliSource/UI/Drawable/StandardUIDrawable.h
@@ -152,18 +152,21 @@ namespace ChilliSource
         /// texture size
         //----------------------------------------------------------------------------------------
         Vector2 GetPreferredSize() const override;
-        //----------------------------------------------------------------------------------------
-        /// Render the widget using the canvas renderer. The widget has is rendered using the
-        /// set texture and UVs.
+        
+        /// Render the widget using the canvas renderer.
         ///
-        /// @author S Downie
+        /// @param renderer
+        ///     Performs the actual drawing to canvas
+        /// @param transform
+        ///     Absolute screen transform
+        /// @param absSize
+        ///     Asbolute screen size
+        /// @param absColour
+        ///     Absolute colour
+        /// @param toMask
+        ///     Whether to create a clip mask for this drawable
         ///
-        /// @param Renderer
-        /// @param Absolute screen transform
-        /// @param Asbolute screen size
-        /// @param Absolute colour
-        //----------------------------------------------------------------------------------------
-        void Draw(CanvasRenderer* in_renderer, const Matrix3& in_transform, const Vector2& in_absSize, const Colour& in_absColour) override;
+        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept override;
         
     private:
         friend class StandardUIDrawableDef;

--- a/Source/ChilliSource/UI/Drawable/StandardUIDrawable.h
+++ b/Source/ChilliSource/UI/Drawable/StandardUIDrawable.h
@@ -163,10 +163,10 @@ namespace ChilliSource
         ///     Asbolute screen size
         /// @param absColour
         ///     Absolute colour
-        /// @param toMask
-        ///     Whether to create a clip mask for this drawable
+        /// @param drawMode
+        ///     Whether to create a clip mask for this drawable or just render it
         ///
-        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept override;
+        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, CanvasDrawMode drawMode) noexcept override;
         
     private:
         friend class StandardUIDrawableDef;

--- a/Source/ChilliSource/UI/Drawable/StandardUIDrawableDef.cpp
+++ b/Source/ChilliSource/UI/Drawable/StandardUIDrawableDef.cpp
@@ -31,6 +31,7 @@
 #include <ChilliSource/Core/Base/Application.h>
 #include <ChilliSource/Core/Resource/ResourcePool.h>
 #include <ChilliSource/Core/String/StringParser.h>
+#include <ChilliSource/Rendering/Base/CanvasDrawMode.h>
 #include <ChilliSource/Rendering/Texture/Texture.h>
 #include <ChilliSource/Rendering/Texture/TextureAtlas.h>
 #include <ChilliSource/UI/Drawable/StandardUIDrawable.h>
@@ -43,6 +44,7 @@ namespace ChilliSource
     //--------------------------------------------------------------
     //--------------------------------------------------------------
     StandardUIDrawableDef::StandardUIDrawableDef(const Json::Value& in_json, StorageLocation in_defaultLocation, const std::string& in_defaultPath)
+    : m_drawMode(CanvasDrawMode::k_standard)
     {
         const char k_typeKey[] = "Type";
         const char k_textureLocationKey[] = "TextureLocation";
@@ -52,7 +54,7 @@ namespace ChilliSource
         const char k_atlasIdKey[] = "AtlasId";
         const char k_uvsKey[] = "UVs";
         const char k_colourKey[] = "Colour";
-        const char k_maskKey[] = "Masking";
+        const char k_drawModeKey[] = "DrawMode";
         
         CS_ASSERT(in_json.isObject() == true, "UIDrawable Def must be created from a json value of type Object.");
         
@@ -97,9 +99,9 @@ namespace ChilliSource
             {
                 m_colour = ParseColour(value);
             }
-            else if (key == k_maskKey)
+            else if (key == k_drawModeKey)
             {
-                m_isMask = ParseBool(value);
+                m_drawMode = ParseCanvasDrawMode(value);
             }
             else if (key == k_typeKey)
             {
@@ -145,14 +147,14 @@ namespace ChilliSource
     //--------------------------------------------------------------
     //--------------------------------------------------------------
     StandardUIDrawableDef::StandardUIDrawableDef(const TextureCSPtr& in_texture, const Colour& in_colour, const UVs& in_uvs)
-        : m_texture(in_texture), m_colour(in_colour), m_uvs(in_uvs)
+    : m_texture(in_texture), m_colour(in_colour), m_uvs(in_uvs), m_drawMode(CanvasDrawMode::k_standard)
     {
         CS_ASSERT(m_texture != nullptr, "The texture cannot be null in a Standard UIDrawable Def.");
     }
     //--------------------------------------------------------------
     //--------------------------------------------------------------
     StandardUIDrawableDef::StandardUIDrawableDef(const TextureCSPtr& in_texture, const TextureAtlasCSPtr& in_atlas, const std::string& in_atlasId, const Colour& in_colour, const UVs& in_uvs)
-        : m_texture(in_texture), m_atlas(in_atlas), m_atlasId(in_atlasId), m_colour(in_colour), m_uvs(in_uvs)
+    : m_texture(in_texture), m_atlas(in_atlas), m_atlasId(in_atlasId), m_colour(in_colour), m_uvs(in_uvs), m_drawMode(CanvasDrawMode::k_standard)
     {
         CS_ASSERT(m_texture != nullptr, "The texture cannot be null in a Standard UIDrawable Def.");
         CS_ASSERT(m_atlas != nullptr, "Cannot specify a null texture atlas in a Standard UIDrawable Def. Use the texture only constructor instead.");

--- a/Source/ChilliSource/UI/Drawable/StandardUIDrawableDef.cpp
+++ b/Source/ChilliSource/UI/Drawable/StandardUIDrawableDef.cpp
@@ -52,6 +52,7 @@ namespace ChilliSource
         const char k_atlasIdKey[] = "AtlasId";
         const char k_uvsKey[] = "UVs";
         const char k_colourKey[] = "Colour";
+        const char k_maskKey[] = "Masking";
         
         CS_ASSERT(in_json.isObject() == true, "UIDrawable Def must be created from a json value of type Object.");
         
@@ -95,6 +96,10 @@ namespace ChilliSource
             else if (key == k_colourKey)
             {
                 m_colour = ParseColour(value);
+            }
+            else if (key == k_maskKey)
+            {
+                m_isMask = ParseBool(value);
             }
             else if (key == k_typeKey)
             {

--- a/Source/ChilliSource/UI/Drawable/StandardUIDrawableDef.h
+++ b/Source/ChilliSource/UI/Drawable/StandardUIDrawableDef.h
@@ -145,9 +145,9 @@ namespace ChilliSource
         //--------------------------------------------------------------
         const Colour& GetColour() const override;
         
-        /// @return Whether the drawable creates a clipping mask
+        /// @return Draw mode of the drawable
         ///
-        bool IsMask() const noexcept override { return m_isMask; }
+        CanvasDrawMode GetDrawMode() const noexcept override { return m_drawMode; }
         
     private:
         //--------------------------------------------------------------
@@ -166,8 +166,7 @@ namespace ChilliSource
         std::string m_atlasId;
         UVs m_uvs;
         Colour m_colour;
-        
-        bool m_isMask = false;
+        CanvasDrawMode m_drawMode;
     };
 }
 

--- a/Source/ChilliSource/UI/Drawable/StandardUIDrawableDef.h
+++ b/Source/ChilliSource/UI/Drawable/StandardUIDrawableDef.h
@@ -145,6 +145,10 @@ namespace ChilliSource
         //--------------------------------------------------------------
         const Colour& GetColour() const override;
         
+        /// @return Whether the drawable creates a clipping mask
+        ///
+        bool IsMask() const noexcept override { return m_isMask; }
+        
     private:
         //--------------------------------------------------------------
         /// Creates a new instance of a standard drawable as described
@@ -162,6 +166,8 @@ namespace ChilliSource
         std::string m_atlasId;
         UVs m_uvs;
         Colour m_colour;
+        
+        bool m_isMask = false;
     };
 }
 

--- a/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawable.cpp
+++ b/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawable.cpp
@@ -615,21 +615,10 @@ namespace ChilliSource
         
         UpdatePatchCache(absSize);
 
-        if(toMask == false)
+        for(u32 i=0; i<k_numPatches; ++i)
         {
-            for(u32 i=0; i<k_numPatches; ++i)
-            {
-                Matrix3 patchTransform = Matrix3::CreateTranslation(m_cachedPositions[i]);
-                renderer->DrawBox(patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], absColour * m_colour, AlignmentAnchor::k_middleCentre);
-            }
-        }
-        else
-        {
-            for(u32 i=0; i<k_numPatches; ++i)
-            {
-                Matrix3 patchTransform = Matrix3::CreateTranslation(m_cachedPositions[i]);
-                renderer->DrawMaskedBox(patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], AlignmentAnchor::k_middleCentre);
-            }
+            Matrix3 patchTransform = Matrix3::CreateTranslation(m_cachedPositions[i]);
+            renderer->DrawBox(patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], absColour * m_colour, AlignmentAnchor::k_middleCentre, toMask);
         }
     }
 }

--- a/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawable.cpp
+++ b/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawable.cpp
@@ -609,7 +609,7 @@ namespace ChilliSource
     }
     //----------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------
-    void ThreePatchUIDrawable::Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept
+    void ThreePatchUIDrawable::Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, CanvasDrawMode drawMode) noexcept
     {
         CS_ASSERT(m_texture != nullptr, "ThreePatchUIDrawable cannot draw without texture");
         
@@ -618,7 +618,7 @@ namespace ChilliSource
         for(u32 i=0; i<k_numPatches; ++i)
         {
             Matrix3 patchTransform = Matrix3::CreateTranslation(m_cachedPositions[i]);
-            renderer->DrawBox(patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], absColour * m_colour, AlignmentAnchor::k_middleCentre, toMask);
+            renderer->DrawBox(drawMode, patchTransform * transform, m_cachedSizes[i], m_cachedOffsetTL, m_texture, m_cachedUvs[i], absColour * m_colour, AlignmentAnchor::k_middleCentre);
         }
     }
 }

--- a/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawable.h
+++ b/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawable.h
@@ -195,10 +195,10 @@ namespace ChilliSource
         ///     Asbolute screen size
         /// @param absColour
         ///     Absolute colour
-        /// @param toMask
-        ///     Whether or not to create a clipping mask from this drawable
+        /// @param drawMode
+        ///     Whether or not to create a clipping mask from this drawable or just render to screen
         ///
-        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept override;
+        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, CanvasDrawMode drawMode) noexcept override;
         
     private:
         friend class ThreePatchUIDrawableDef;

--- a/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawable.h
+++ b/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawable.h
@@ -184,18 +184,21 @@ namespace ChilliSource
         /// texture size
         //----------------------------------------------------------------------------------------
         Vector2 GetPreferredSize() const override;
-        //----------------------------------------------------------------------------------------
-        /// Render the widget using the canvas renderer. The widget has is rendered using the
-        /// set texture and UVs.
+        
+        /// Render the widget using the canvas renderer.
         ///
-        /// @author S Downie
+        /// @param renderer
+        ///     Performs the actual drawing to canvas
+        /// @param transform
+        ///     Absolute screen transform
+        /// @param absSize
+        ///     Asbolute screen size
+        /// @param absColour
+        ///     Absolute colour
+        /// @param toMask
+        ///     Whether or not to create a clipping mask from this drawable
         ///
-        /// @param Renderer
-        /// @param Absolute screen transform
-        /// @param Asbolute screen size
-        /// @param Absolute colour
-        //----------------------------------------------------------------------------------------
-        void Draw(CanvasRenderer* in_renderer, const Matrix3& in_transform, const Vector2& in_absSize, const Colour& in_absColour) override;
+        void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept override;
         
     private:
         friend class ThreePatchUIDrawableDef;
@@ -278,6 +281,14 @@ namespace ChilliSource
         /// This should be provided as a normalised fraction, 0.0 - 1.0.
         //----------------------------------------------------------------------------------------
         ThreePatchUIDrawable(const TextureCSPtr& in_texture, const TextureAtlasCSPtr& in_atlas, const std::string& in_atlasId, Direction in_direction, f32 in_leftOrBottom, f32 in_rightOrTop);
+        
+        /// Patches (size, pos, etc) are calculated and cached. This function when called will
+        /// update the cache if required, otherwise it will do nothing
+        ///
+        /// @param absSize
+        ///     Canvas space size of the widget, if changed from last draw, update the cache
+        ///
+        void UpdatePatchCache(const Vector2& absSize);
         
         CalculateUVsDelegate m_uvCalculationDelegate;
         CalculateSizesDelegate m_sizeCalculationDelegate;

--- a/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawableDef.cpp
+++ b/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawableDef.cpp
@@ -31,6 +31,7 @@
 #include <ChilliSource/Core/Base/Application.h>
 #include <ChilliSource/Core/Resource/ResourcePool.h>
 #include <ChilliSource/Core/String/StringParser.h>
+#include <ChilliSource/Rendering/Base/CanvasDrawMode.h>
 #include <ChilliSource/Rendering/Texture/Texture.h>
 #include <ChilliSource/Rendering/Texture/TextureAtlas.h>
 
@@ -76,6 +77,7 @@ namespace ChilliSource
     //--------------------------------------------------------------
     //--------------------------------------------------------------
     ThreePatchUIDrawableDef::ThreePatchUIDrawableDef(const Json::Value& in_json, StorageLocation in_defaultLocation, const std::string& in_defaultPath)
+    : m_drawMode(CanvasDrawMode::k_standard)
     {
         const char k_typeKey[] = "Type";
         const char k_textureLocationKey[] = "TextureLocation";
@@ -87,7 +89,7 @@ namespace ChilliSource
         const char k_colourKey[] = "Colour";
         const char k_insetsKey[] = "Insets";
         const char k_directionKey[] = "Direction";
-        const char k_maskKey[] = "Masking";
+        const char k_drawModeKey[] = "DrawMode";
         
         CS_ASSERT(in_json.isObject() == true, "UIDrawable Def must be created from a json value of type Object.");
         
@@ -140,9 +142,9 @@ namespace ChilliSource
             {
                 m_direction = ParseThreePatchDirection(value);
             }
-            else if (key == k_maskKey)
+            else if (key == k_drawModeKey)
             {
-                m_isMask = ParseBool(value);
+                m_drawMode = ParseCanvasDrawMode(value);
             }
             else if (key == k_typeKey)
             {
@@ -188,7 +190,7 @@ namespace ChilliSource
     //--------------------------------------------------------------
     //--------------------------------------------------------------
     ThreePatchUIDrawableDef::ThreePatchUIDrawableDef(const TextureCSPtr& in_texture, const Vector2& in_insets, ThreePatchUIDrawable::Direction in_direction, const Colour& in_colour, const UVs& in_uvs)
-        : m_texture(in_texture), m_insets(in_insets), m_direction(in_direction), m_colour(in_colour), m_uvs(in_uvs)
+    : m_texture(in_texture), m_insets(in_insets), m_direction(in_direction), m_colour(in_colour), m_uvs(in_uvs), m_drawMode(CanvasDrawMode::k_standard)
     {
         CS_ASSERT(m_texture != nullptr, "The texture cannot be null in a Three-Patch UIDrawable Def.");
     }
@@ -196,7 +198,7 @@ namespace ChilliSource
     //--------------------------------------------------------------
     ThreePatchUIDrawableDef::ThreePatchUIDrawableDef(const TextureCSPtr& in_texture, const TextureAtlasCSPtr& in_atlas, const std::string& in_atlasId, const Vector2& in_insets, ThreePatchUIDrawable::Direction in_direction,
                                                  const Colour& in_colour, const UVs& in_uvs)
-        : m_texture(in_texture), m_atlas(in_atlas), m_atlasId(in_atlasId), m_insets(in_insets), m_direction(in_direction), m_colour(in_colour), m_uvs(in_uvs)
+    : m_texture(in_texture), m_atlas(in_atlas), m_atlasId(in_atlasId), m_insets(in_insets), m_direction(in_direction), m_colour(in_colour), m_uvs(in_uvs), m_drawMode(CanvasDrawMode::k_standard)
     {
         CS_ASSERT(m_texture != nullptr, "The texture cannot be null in a Three-Patch UIDrawable Def.");
         CS_ASSERT(m_atlas != nullptr, "Cannot specify a null texture atlas in a Three-Patch UIDrawable Def. Use the texture only constructor instead.");

--- a/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawableDef.cpp
+++ b/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawableDef.cpp
@@ -87,6 +87,7 @@ namespace ChilliSource
         const char k_colourKey[] = "Colour";
         const char k_insetsKey[] = "Insets";
         const char k_directionKey[] = "Direction";
+        const char k_maskKey[] = "Masking";
         
         CS_ASSERT(in_json.isObject() == true, "UIDrawable Def must be created from a json value of type Object.");
         
@@ -138,6 +139,10 @@ namespace ChilliSource
             else if (key == k_directionKey)
             {
                 m_direction = ParseThreePatchDirection(value);
+            }
+            else if (key == k_maskKey)
+            {
+                m_isMask = ParseBool(value);
             }
             else if (key == k_typeKey)
             {

--- a/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawableDef.h
+++ b/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawableDef.h
@@ -172,6 +172,10 @@ namespace ChilliSource
         //--------------------------------------------------------------
         ThreePatchUIDrawable::Direction GetDirection() const;
         
+        /// @return Whether the drawable creates a clipping mask
+        ///
+        bool IsMask() const noexcept override { return m_isMask; }
+        
     private:
         //--------------------------------------------------------------
         /// Creates a new instance of a standard drawable as described
@@ -191,6 +195,7 @@ namespace ChilliSource
         Colour m_colour;
         Vector2 m_insets;
         ThreePatchUIDrawable::Direction m_direction;
+        bool m_isMask = false;
     };
 }
 

--- a/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawableDef.h
+++ b/Source/ChilliSource/UI/Drawable/ThreePatchUIDrawableDef.h
@@ -172,9 +172,9 @@ namespace ChilliSource
         //--------------------------------------------------------------
         ThreePatchUIDrawable::Direction GetDirection() const;
         
-        /// @return Whether the drawable creates a clipping mask
+        /// @return Draw mode of the drawable
         ///
-        bool IsMask() const noexcept override { return m_isMask; }
+        CanvasDrawMode GetDrawMode() const noexcept override { return m_drawMode; }
         
     private:
         //--------------------------------------------------------------
@@ -195,7 +195,7 @@ namespace ChilliSource
         Colour m_colour;
         Vector2 m_insets;
         ThreePatchUIDrawable::Direction m_direction;
-        bool m_isMask = false;
+        CanvasDrawMode m_drawMode;
     };
 }
 

--- a/Source/ChilliSource/UI/Drawable/UIDrawable.h
+++ b/Source/ChilliSource/UI/Drawable/UIDrawable.h
@@ -156,10 +156,10 @@ namespace ChilliSource
         ///     Asbolute screen size
         /// @param absColour
         ///     Absolute colour
-        /// @param toMask
-        ///     Whether or not to create a clipping mask from this drawable
+        /// @param drawMode
+        ///     Whether or not to create a clipping mask from this drawable or just render it
         ///
-        virtual void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept = 0;
+        virtual void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, CanvasDrawMode drawMode) noexcept = 0;
         //----------------------------------------------------------------------------------------
         /// Virtual destructor
         ///

--- a/Source/ChilliSource/UI/Drawable/UIDrawable.h
+++ b/Source/ChilliSource/UI/Drawable/UIDrawable.h
@@ -145,17 +145,21 @@ namespace ChilliSource
         /// @param The colour.
         //----------------------------------------------------------------------------------------
         virtual void SetColour(const Colour& in_colour) = 0;
-        //----------------------------------------------------------------------------------------
-        /// Render the widget using the canvas renderer
+        
+        /// Render the widget using the canvas renderer.
         ///
-        /// @author S Downie
+        /// @param renderer
+        ///     Performs the actual drawing to canvas
+        /// @param transform
+        ///     Absolute screen transform
+        /// @param absSize
+        ///     Asbolute screen size
+        /// @param absColour
+        ///     Absolute colour
+        /// @param toMask
+        ///     Whether or not to create a clipping mask from this drawable
         ///
-        /// @param Renderer
-        /// @param Absolute screen space transform
-        /// @param Asbolute screen size
-        /// @param Absolute colour
-        //----------------------------------------------------------------------------------------
-        virtual void Draw(CanvasRenderer* in_renderer, const Matrix3& in_transform, const Vector2& in_absSize, const Colour& in_absColour) = 0;
+        virtual void Draw(CanvasRenderer* renderer, const Matrix3& transform, const Vector2& absSize, const Colour& absColour, bool toMask) noexcept = 0;
         //----------------------------------------------------------------------------------------
         /// Virtual destructor
         ///

--- a/Source/ChilliSource/UI/Drawable/UIDrawableDef.h
+++ b/Source/ChilliSource/UI/Drawable/UIDrawableDef.h
@@ -73,7 +73,10 @@ namespace ChilliSource
     ///
     /// "Colour": The colour of the drawable.
     ///
-    /// "Masking": True or False - Whether the widget should create a child clipping mask
+    /// "DrawMode": Describes the draw mode for this drawable
+    ///     "Standard" - Draw to canvas as usual
+    ///     "Mask" - Draw to canvas and create a clip mask
+    ///     "MaskOnly" - Don't render to canvas just create the clip mask
     ///
     /// @author Ian Copland
     //---------------------------------------------------------------------
@@ -132,9 +135,9 @@ namespace ChilliSource
         //--------------------------------------------------------------
         virtual const Colour& GetColour() const = 0;
         
-        /// @return Whether the drawable creates a clipping mask
+        /// @return Draw mode of the drawable
         ///
-        virtual bool IsMask() const noexcept = 0;
+        virtual CanvasDrawMode GetDrawMode() const noexcept = 0;
         
         //--------------------------------------------------------------
         /// Destructor

--- a/Source/ChilliSource/UI/Drawable/UIDrawableDef.h
+++ b/Source/ChilliSource/UI/Drawable/UIDrawableDef.h
@@ -73,6 +73,8 @@ namespace ChilliSource
     ///
     /// "Colour": The colour of the drawable.
     ///
+    /// "Masking": True or False - Whether the widget should create a child clipping mask
+    ///
     /// @author Ian Copland
     //---------------------------------------------------------------------
     class UIDrawableDef : public QueryableInterface
@@ -129,6 +131,11 @@ namespace ChilliSource
         /// @param The colour of the drawable.
         //--------------------------------------------------------------
         virtual const Colour& GetColour() const = 0;
+        
+        /// @return Whether the drawable creates a clipping mask
+        ///
+        virtual bool IsMask() const noexcept = 0;
+        
         //--------------------------------------------------------------
         /// Destructor
         ///

--- a/Source/ChilliSource/UI/Text/TextUIComponent.cpp
+++ b/Source/ChilliSource/UI/Text/TextUIComponent.cpp
@@ -512,7 +512,7 @@ namespace ChilliSource
         // Draw images
         for(const auto& iconData : m_cachedIcons)
         {
-            in_renderer->DrawBox(in_transform, iconData.m_size, iconData.m_offset, iconData.m_texture, iconData.m_uvs, GetWidget()->GetFinalColour(), AlignmentAnchor::k_middleCentre);
+            in_renderer->DrawBox(in_transform, iconData.m_size, iconData.m_offset, iconData.m_texture, iconData.m_uvs, GetWidget()->GetFinalColour(), AlignmentAnchor::k_middleCentre, false);
         }
     }
 }

--- a/Source/ChilliSource/UI/Text/TextUIComponent.cpp
+++ b/Source/ChilliSource/UI/Text/TextUIComponent.cpp
@@ -34,6 +34,7 @@
 #include <ChilliSource/Core/Localisation/LocalisedText.h>
 #include <ChilliSource/Core/Resource/ResourcePool.h>
 #include <ChilliSource/Core/String/StringParser.h>
+#include <ChilliSource/Rendering/Base/CanvasDrawMode.h>
 #include <ChilliSource/Rendering/Font/Font.h>
 #include <ChilliSource/Rendering/Texture/Texture.h>
 #include <ChilliSource/Rendering/Texture/TextureAtlas.h>
@@ -512,7 +513,7 @@ namespace ChilliSource
         // Draw images
         for(const auto& iconData : m_cachedIcons)
         {
-            in_renderer->DrawBox(in_transform, iconData.m_size, iconData.m_offset, iconData.m_texture, iconData.m_uvs, GetWidget()->GetFinalColour(), AlignmentAnchor::k_middleCentre, false);
+            in_renderer->DrawBox(CanvasDrawMode::k_standard, in_transform, iconData.m_size, iconData.m_offset, iconData.m_texture, iconData.m_uvs, GetWidget()->GetFinalColour(), AlignmentAnchor::k_middleCentre);
         }
     }
 }


### PR DESCRIPTION
* Subview clipping had been removed as part of the renderer overhaul, this branch will add it back in (but improved).
* New clipping uses the stencil buffer rather than glScissor regions to allow arbitrarily shaped masks.
* Masking widgets can now also be rotated.
* Masking is no longer handled by the widget but has been offloaded to drawables.
* Drawables now have a mode that specifies whether they draw as standard, draw as standard and create a clipping mask or just create a clipping mask (used for invisible clip regions)
* Example can be found in equivalent feature branch of CS Test

![img_0732](https://cloud.githubusercontent.com/assets/6662661/17172090/6b0e830e-53eb-11e6-91c6-17b072abf7ba.PNG)
