### PR TITLE
Fix/web view dismiss

### DIFF
--- a/Source/CSBackend/Platform/iOS/Web/Base/WebView.mm
+++ b/Source/CSBackend/Platform/iOS/Web/Base/WebView.mm
@@ -220,8 +220,8 @@ namespace CSBackend
                         DismissedDelegate delegate = m_dismissedDelegate;
                         m_dismissedDelegate = nullptr;
                         delegate();
+                        m_currentState = State::k_inactive;
                     }
-                    m_currentState = State::k_inactive;
                 });
             });
 		}

--- a/Source/CSBackend/Platform/iOS/Web/Base/WebView.mm
+++ b/Source/CSBackend/Platform/iOS/Web/Base/WebView.mm
@@ -220,8 +220,8 @@ namespace CSBackend
                         DismissedDelegate delegate = m_dismissedDelegate;
                         m_dismissedDelegate = nullptr;
                         delegate();
-                        m_currentState = State::k_inactive;
                     }
+                    m_currentState = State::k_inactive;
                 });
             });
 		}


### PR DESCRIPTION
Fixed an issue where the iOS web view system would be stuck in the dismissing state unless a dismiss delegate was supplied when requesting an internal web view. Modev the state change outside the delegate nullptr check. 